### PR TITLE
Change database blob audio storage to file based audio storage.

### DIFF
--- a/server/call.go
+++ b/server/call.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -71,6 +72,7 @@ type Call struct {
 	Audio         []byte
 	AudioFilename string
 	AudioMime     string
+	AudioPath     string
 	Delayed       bool
 	Frequencies   []CallFrequency
 	Meta          CallMeta
@@ -201,8 +203,6 @@ func NewCalls(controller *Controller) *Calls {
 }
 
 func (calls *Calls) CheckDuplicate(call *Call, msTimeFrame uint, db *Database) (bool, error) {
-	var count uint64
-
 	calls.mutex.Lock()
 	defer calls.mutex.Unlock()
 
@@ -212,12 +212,18 @@ func (calls *Calls) CheckDuplicate(call *Call, msTimeFrame uint, db *Database) (
 	from := call.Timestamp.Add(-d)
 	to := call.Timestamp.Add(d)
 
-	query := fmt.Sprintf(`SELECT COUNT(*) FROM "calls" WHERE ("timestamp" BETWEEN %d and %d) AND "systemId" = %d AND "talkgroupId" = %d`, from.UnixMilli(), to.UnixMilli(), call.System.Id, call.Talkgroup.Id)
-	if err := db.Sql.QueryRow(query).Scan(&count); err != nil {
+	// SELECT 1 ... LIMIT 1 short-circuits at the first matching row,
+	// rather than counting every match across the whole window.
+	query := fmt.Sprintf(`SELECT 1 FROM "calls" WHERE ("timestamp" BETWEEN %d and %d) AND "systemId" = %d AND "talkgroupId" = %d LIMIT 1`, from.UnixMilli(), to.UnixMilli(), call.System.Id, call.Talkgroup.Id)
+	var found int
+	switch err := db.Sql.QueryRow(query).Scan(&found); err {
+	case nil:
+		return true, nil
+	case sql.ErrNoRows:
+		return false, nil
+	default:
 		return false, formatError(err, query)
 	}
-
-	return count > 0, nil
 }
 
 func (calls *Calls) GetCall(id uint64) (*Call, error) {
@@ -244,16 +250,31 @@ func (calls *Calls) GetCall(id uint64) (*Call, error) {
 
 	call := Call{Id: id}
 
+	// c.systemId and c.talkgroupId are taken directly from the calls row;
+	// the prior LEFT JOINs to systems/talkgroups existed only to re-select
+	// those columns and are pure overhead (FK constraints guarantee the
+	// references resolve, and Go re-looks up against in-memory caches anyway).
 	if calls.controller.Database.Config.DbType == DbTypePostgresql {
-		query = fmt.Sprintf(`SELECT c."audio", c."audioFilename", c."audioMime", c."siteRef", c."timestamp", STRING_AGG(CAST(COALESCE(cpt."talkgroupRef", 0) AS text), ','), c."siteRef", sy."systemId", t."talkgroupId" FROM "calls" AS c LEFT JOIN "callPatches" AS cp on cp."callId" = c."callId" LEFT JOIN "talkgroups" AS cpt ON cpt."talkgroupId" = cp."talkgroupId" LEFT JOIN "systems" AS sy ON sy."systemId" = c."systemId" LEFT JOIN "talkgroups" AS t ON t."talkgroupId" = c."talkgroupId" WHERE c."callId" = %d GROUP BY c."callId"`, id)
+		query = fmt.Sprintf(`SELECT c."audio", c."audioFilename", c."audioMime", c."audioPath", c."siteRef", c."timestamp", STRING_AGG(CAST(COALESCE(cpt."talkgroupRef", 0) AS text), ','), c."systemId", c."talkgroupId" FROM "calls" AS c LEFT JOIN "callPatches" AS cp on cp."callId" = c."callId" LEFT JOIN "talkgroups" AS cpt ON cpt."talkgroupId" = cp."talkgroupId" WHERE c."callId" = %d GROUP BY c."callId"`, id)
 
 	} else {
-		query = fmt.Sprintf(`SELECT c."audio", c."audioFilename", c."audioMime", c."siteRef", c."timestamp", GROUP_CONCAT(COALESCE(cpt."talkgroupRef", 0)), c."siteRef", sy."systemId", t."talkgroupId" FROM "calls" AS c LEFT JOIN "callPatches" AS cp on cp."callId" = c."callId" LEFT JOIN "talkgroups" AS cpt ON cpt."talkgroupId" = cp."talkgroupId" LEFT JOIN "systems" AS sy ON sy."systemId" = c."systemId" LEFT JOIN "talkgroups" AS t ON t."talkgroupId" = c."talkgroupId" WHERE c."callId" = %d GROUP BY c."callId"`, id)
+		query = fmt.Sprintf(`SELECT c."audio", c."audioFilename", c."audioMime", c."audioPath", c."siteRef", c."timestamp", GROUP_CONCAT(COALESCE(cpt."talkgroupRef", 0)), c."systemId", c."talkgroupId" FROM "calls" AS c LEFT JOIN "callPatches" AS cp on cp."callId" = c."callId" LEFT JOIN "talkgroups" AS cpt ON cpt."talkgroupId" = cp."talkgroupId" WHERE c."callId" = %d GROUP BY c."callId"`, id)
 	}
 
-	if err = tx.QueryRow(query).Scan(&call.Audio, &call.AudioFilename, &call.AudioMime, &patch, &timestamp, &patch, &call.SiteRef, &systemId, &talkgroupId); err != nil && err != sql.ErrNoRows {
+	if err = tx.QueryRow(query).Scan(&call.Audio, &call.AudioFilename, &call.AudioMime, &call.AudioPath, &call.SiteRef, &timestamp, &patch, &systemId, &talkgroupId); err != nil && err != sql.ErrNoRows {
 		tx.Rollback()
 		return nil, formatError(err, query)
+	}
+
+	// File-backed rows have audio on disk; legacy rows still have it in
+	// the BLOB column. Load from disk when we have a path.
+	if call.AudioPath != "" {
+		if b, readErr := readAudioFile(call.AudioPath); readErr == nil {
+			call.Audio = b
+		} else {
+			tx.Rollback()
+			return nil, formatError(readErr, call.AudioPath)
+		}
 	}
 
 	call.Timestamp = time.UnixMilli(timestamp)
@@ -329,15 +350,167 @@ func (calls *Calls) GetCall(id uint64) (*Call, error) {
 	return &call, nil
 }
 
+// BackfillBlobs migrates legacy rows (audio bytes in the DB blob, no audioPath)
+// to file-backed storage. Safe to run alongside ingestion: legacy rows are
+// effectively immutable except for Prune, which races harmlessly with the
+// per-row UPDATE here (an UPDATE that affects 0 rows is a no-op). Resumable
+// on restart because the SELECT keeps finding un-migrated rows.
+func (calls *Calls) BackfillBlobs() {
+	const (
+		batchSize     = 100
+		batchInterval = 50 * time.Millisecond
+	)
+
+	formatError := errorFormatter("calls", "backfillblobs")
+
+	db := calls.controller.Database
+	config := calls.controller.Config
+
+	type legacyRow struct {
+		id            uint64
+		audio         []byte
+		audioFilename string
+		audioMime     string
+		systemId      uint64
+		talkgroupId   uint64
+		timestamp     int64
+	}
+
+	migrated := uint64(0)
+	failed := uint64(0)
+	scanned := false
+
+	for {
+		batch := []legacyRow{}
+
+		query := fmt.Sprintf(`SELECT "callId", "audio", "audioFilename", "audioMime", "systemId", "talkgroupId", "timestamp" FROM "calls" WHERE "audioPath" = '' LIMIT %d`, batchSize)
+		rows, err := db.Sql.Query(query)
+		if err != nil {
+			log.Println(formatError(err, query))
+			return
+		}
+		for rows.Next() {
+			var r legacyRow
+			if err := rows.Scan(&r.id, &r.audio, &r.audioFilename, &r.audioMime, &r.systemId, &r.talkgroupId, &r.timestamp); err == nil {
+				batch = append(batch, r)
+			}
+		}
+		rows.Close()
+
+		if len(batch) == 0 {
+			if scanned {
+				log.Printf("audio backfill: complete (%d migrated, %d skipped)", migrated, failed)
+			}
+			return
+		}
+		if !scanned {
+			log.Println("audio backfill: starting")
+			scanned = true
+		}
+
+		for _, r := range batch {
+			// Empty BLOB = legacy row with no audio at all; mark it as
+			// migrated by setting audioPath to a sentinel that won't match
+			// real files, so the SELECT stops finding it.
+			if len(r.audio) == 0 {
+				update := fmt.Sprintf(`UPDATE "calls" SET "audioPath" = '-' WHERE "callId" = %d`, r.id)
+				if _, err := db.Sql.Exec(update); err != nil {
+					log.Println(formatError(err, update))
+					failed++
+				}
+				continue
+			}
+
+			sys, ok := calls.controller.Systems.GetSystemById(r.systemId)
+			if !ok {
+				log.Println(formatError(fmt.Errorf("system %d not found for call %d", r.systemId, r.id), ""))
+				failed++
+				continue
+			}
+			tg, ok := sys.Talkgroups.GetTalkgroupById(r.talkgroupId)
+			if !ok {
+				log.Println(formatError(fmt.Errorf("talkgroup %d not found for call %d", r.talkgroupId, r.id), ""))
+				failed++
+				continue
+			}
+
+			stub := &Call{
+				Id:            r.id,
+				AudioFilename: r.audioFilename,
+				AudioMime:     r.audioMime,
+				System:        sys,
+				Talkgroup:     tg,
+				Timestamp:     time.UnixMilli(r.timestamp),
+			}
+
+			path, err := buildAudioFilePath(config, stub)
+			if err != nil {
+				log.Println(formatError(err, ""))
+				failed++
+				continue
+			}
+			if err := writeAudioFile(path, r.audio); err != nil {
+				log.Println(formatError(err, ""))
+				failed++
+				continue
+			}
+
+			// Clear the BLOB and store the path. If the UPDATE fails we
+			// leave the file on disk to be picked up on the next attempt
+			// (the SELECT will return the row again).
+			update := fmt.Sprintf(`UPDATE "calls" SET "audioPath" = '%s', "audio" = ? WHERE "callId" = %d`, escapeQuotes(path), r.id)
+			if _, err := db.Sql.Exec(update, []byte{}); err != nil {
+				log.Println(formatError(err, update))
+				if rmErr := deleteAudioFile(path); rmErr != nil {
+					log.Println(formatError(rmErr, "cleanup"))
+				}
+				failed++
+				continue
+			}
+
+			migrated++
+		}
+
+		if migrated > 0 && migrated%1000 < uint64(batchSize) {
+			log.Printf("audio backfill: %d rows migrated so far", migrated)
+		}
+
+		time.Sleep(batchInterval)
+	}
+}
+
 func (calls *Calls) Prune(db *Database, pruneDays uint) error {
 	calls.mutex.Lock()
 	defer calls.mutex.Unlock()
 
 	timestamp := time.Now().Add(-24 * time.Hour * time.Duration(pruneDays)).UnixMilli()
-	query := fmt.Sprintf(`DELETE FROM "calls" WHERE "timestamp" < %d`, timestamp)
 
-	if _, err := db.Sql.Exec(query); err != nil {
-		return fmt.Errorf("%s in %s", err, query)
+	// Collect the audio file paths for soon-to-be-deleted rows so we can
+	// remove them from disk after the DB delete succeeds. Best-effort:
+	// an orphan file is preferable to a row pointing at a missing file.
+	var audioPaths []string
+	selectQuery := fmt.Sprintf(`SELECT "audioPath" FROM "calls" WHERE "timestamp" < %d AND "audioPath" <> ''`, timestamp)
+	if rows, err := db.Sql.Query(selectQuery); err == nil {
+		for rows.Next() {
+			var p sql.NullString
+			if err := rows.Scan(&p); err == nil && p.Valid && p.String != "" {
+				audioPaths = append(audioPaths, p.String)
+			}
+		}
+		rows.Close()
+	} else {
+		log.Println(fmt.Errorf("calls.prune: %s in %s", err, selectQuery))
+	}
+
+	deleteQuery := fmt.Sprintf(`DELETE FROM "calls" WHERE "timestamp" < %d`, timestamp)
+	if _, err := db.Sql.Exec(deleteQuery); err != nil {
+		return fmt.Errorf("%s in %s", err, deleteQuery)
+	}
+
+	for _, p := range audioPaths {
+		if err := deleteAudioFile(p); err != nil {
+			log.Println(fmt.Errorf("calls.prune: %s", err))
+		}
 	}
 
 	return nil
@@ -438,19 +611,20 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 		}
 	}
 
-	query = fmt.Sprintf(`SELECT c."timestamp" FROM "calls" AS c LEFT JOIN "systems" AS s ON s."systemId" = c."systemId" LEFT JOIN "talkgroups" AS t ON t."talkgroupId" = c."talkgroupId" LEFT JOIN "delayed" AS d ON d."callId" = c."callId" WHERE %s ORDER BY c."timestamp" ASC`, where)
-	if err = db.Sql.QueryRow(query).Scan(&timestamp); err != nil && err != sql.ErrNoRows {
+	// Aggregate MIN/MAX in one round-trip; with idx_calls_timestamp these
+	// resolve as index lookups rather than full sorts of the filtered set.
+	var minTs, maxTs sql.NullInt64
+	query = fmt.Sprintf(`SELECT MIN(c."timestamp"), MAX(c."timestamp") FROM "calls" AS c LEFT JOIN "systems" AS s ON s."systemId" = c."systemId" LEFT JOIN "talkgroups" AS t ON t."talkgroupId" = c."talkgroupId" LEFT JOIN "delayed" AS d ON d."callId" = c."callId" WHERE %s`, where)
+	if err = db.Sql.QueryRow(query).Scan(&minTs, &maxTs); err != nil && err != sql.ErrNoRows {
 		return nil, formatError(err, query)
 	}
 
-	searchResults.DateStart = time.UnixMilli(timestamp)
-
-	query = fmt.Sprintf(`SELECT c."timestamp" FROM "calls" AS c LEFT JOIN "systems" AS s ON s."systemId" = c."systemId" LEFT JOIN "talkgroups" AS t ON t."talkgroupId" = c."talkgroupId" LEFT JOIN "delayed" AS d ON d."callId" = c."callId" WHERE %s ORDER BY c."timestamp" DESC`, where)
-	if err = db.Sql.QueryRow(query).Scan(&timestamp); err != nil && err != sql.ErrNoRows {
-		return nil, formatError(err, query)
+	if minTs.Valid {
+		searchResults.DateStart = time.UnixMilli(minTs.Int64)
 	}
-
-	searchResults.DateStop = time.UnixMilli(timestamp)
+	if maxTs.Valid {
+		searchResults.DateStop = time.UnixMilli(maxTs.Int64)
+	}
 
 	switch v := searchOptions.Sort.(type) {
 	case int:
@@ -537,19 +711,42 @@ func (calls *Calls) WriteCall(call *Call, db *Database) (uint64, error) {
 
 	formatError := errorFormatter("calls", "writecall")
 
+	// Write audio to disk before opening the transaction. The DB only
+	// stores the path; the BLOB column gets an empty value for new rows.
+	audioPath, err := buildAudioFilePath(calls.controller.Config, call)
+	if err != nil {
+		return 0, formatError(err, "")
+	}
+	if err = writeAudioFile(audioPath, call.Audio); err != nil {
+		return 0, formatError(err, "")
+	}
+	call.AudioPath = audioPath
+
+	// If we don't reach a successful commit, remove the orphan file.
+	committed := false
+	defer func() {
+		if !committed {
+			if rmErr := deleteAudioFile(audioPath); rmErr != nil {
+				log.Println(formatError(rmErr, "cleanup"))
+			}
+		}
+	}()
+
 	if tx, err = db.Sql.Begin(); err != nil {
 		return 0, formatError(err, "")
 	}
 
-	if db.Config.DbType == DbTypePostgresql {
-		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES ($1, '%s', '%s', %d, %d, %d, %d) RETURNING "callId"`, call.AudioFilename, call.AudioMime, call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
+	emptyAudio := []byte{}
 
-		err = tx.QueryRow(query, call.Audio).Scan(&call.Id)
+	if db.Config.DbType == DbTypePostgresql {
+		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "audioPath", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES ($1, '%s', '%s', '%s', %d, %d, %d, %d) RETURNING "callId"`, call.AudioFilename, call.AudioMime, escapeQuotes(call.AudioPath), call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
+
+		err = tx.QueryRow(query, emptyAudio).Scan(&call.Id)
 
 	} else {
-		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES (?, '%s', '%s', %d, %d, %d, %d)`, call.AudioFilename, call.AudioMime, call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
+		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "audioPath", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES (?, '%s', '%s', '%s', %d, %d, %d, %d)`, call.AudioFilename, call.AudioMime, escapeQuotes(call.AudioPath), call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
 
-		if res, err = tx.Exec(query, call.Audio); err == nil {
+		if res, err = tx.Exec(query, emptyAudio); err == nil {
 			if id, err := res.LastInsertId(); err == nil {
 				call.Id = uint64(id)
 			}
@@ -598,6 +795,8 @@ func (calls *Calls) WriteCall(call *Call, db *Database) (uint64, error) {
 		tx.Rollback()
 		return 0, formatError(err, "")
 	}
+
+	committed = true
 
 	return uint64(call.Id), nil
 }

--- a/server/controller.go
+++ b/server/controller.go
@@ -601,6 +601,8 @@ func (controller *Controller) Start() error {
 
 	controller.Dirwatches.Start(controller)
 
+	go controller.Calls.BackfillBlobs()
+
 	return nil
 }
 

--- a/server/database.go
+++ b/server/database.go
@@ -159,6 +159,10 @@ func (db *Database) migrate() error {
 		return formatError(err, "")
 	}
 
+	if err := migrateCallsAudioPath(db); err != nil {
+		return formatError(err, "")
+	}
+
 	if err := migrateApikeys(db); err != nil {
 		return formatError(err, "")
 	}

--- a/server/log.go
+++ b/server/log.go
@@ -185,27 +185,19 @@ func (logs *Logs) Search(searchOptions *LogsSearchOptions, db *Database) (*LogsS
 		offset = v
 	}
 
-	query = fmt.Sprintf(`SELECT "timestamp" FROM "logs" WHERE %s ORDER BY "timestamp" ASC`, where)
-	if err = db.Sql.QueryRow(query).Scan(&timestamp); err != nil && err != sql.ErrNoRows {
+	// MIN/MAX/COUNT share the same WHERE here, so fold into one query —
+	// saves two round-trips and two index scans per log search.
+	var minTs, maxTs sql.NullInt64
+	query = fmt.Sprintf(`SELECT MIN("timestamp"), MAX("timestamp"), COUNT(*) FROM "logs" WHERE %s`, where)
+	if err = db.Sql.QueryRow(query).Scan(&minTs, &maxTs, &logResults.Count); err != nil && err != sql.ErrNoRows {
 		return nil, formatError(err, query)
 	}
 
-	if timestamp.Valid {
-		logResults.DateStart = time.UnixMilli(timestamp.Int64)
+	if minTs.Valid {
+		logResults.DateStart = time.UnixMilli(minTs.Int64)
 	}
-
-	query = fmt.Sprintf(`SELECT "timestamp" FROM "logs" WHERE %s ORDER BY "timestamp" DESC`, where)
-	if err = db.Sql.QueryRow(query).Scan(&timestamp); err != nil && err != sql.ErrNoRows {
-		return nil, formatError(err, query)
-	}
-
-	if timestamp.Valid {
-		logResults.DateStop = time.UnixMilli(timestamp.Int64)
-	}
-
-	query = fmt.Sprintf(`SELECT COUNT(*) FROM "logs" WHERE %s`, where)
-	if err = db.Sql.QueryRow(query).Scan(&logResults.Count); err != nil && err != sql.ErrNoRows {
-		return nil, formatError(err, query)
+	if maxTs.Valid {
+		logResults.DateStop = time.UnixMilli(maxTs.Int64)
 	}
 
 	query = fmt.Sprintf(`SELECT "logId", "level", "message", "timestamp" FROM "logs" WHERE %s ORDER BY "timestamp" %s limit %d offset %d`, where, order, limit, offset)

--- a/server/migrations.go
+++ b/server/migrations.go
@@ -29,6 +29,28 @@ import (
 	"strings"
 )
 
+// migrateCallsAudioPath adds the "audioPath" column to existing "calls"
+// tables. Fresh installs already get the column via the schema seed; this
+// function is for upgrading databases that were created before file-backed
+// audio storage existed.
+func migrateCallsAudioPath(db *Database) error {
+	formatError := errorFormatter("migration", "migrateCallsAudioPath")
+
+	// Probe for the column. If the SELECT succeeds, migration is done.
+	if _, err := db.Sql.Exec(`SELECT "audioPath" FROM "calls" LIMIT 1`); err == nil {
+		return nil
+	}
+
+	log.Println("adding calls.audioPath column...")
+
+	query := `ALTER TABLE "calls" ADD COLUMN "audioPath" text NOT NULL DEFAULT ''`
+	if _, err := db.Sql.Exec(query); err != nil {
+		return formatError(err, query)
+	}
+
+	return nil
+}
+
 func migrateAccesses(db *Database) error {
 	var (
 		err   error

--- a/server/mysql.go
+++ b/server/mysql.go
@@ -117,6 +117,7 @@ var MysqlSchema = []string{
     "audio" blob NOT NULL,
     "audioFilename" text NOT NULL,
     "audioMime" text NOT NULL,
+    "audioPath" text NOT NULL,
     "siteRef" integer NOT NULL DEFAULT 0,
     "systemId" bigint NOT NULL,
     "talkgroupId" bigint NOT NULL,
@@ -126,6 +127,10 @@ var MysqlSchema = []string{
   );`,
 
 	`CREATE INDEX IF NOT EXISTS "calls_idx" ON "calls" ("systemId","siteRef","talkgroupId","timestamp");`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_calls_timestamp" ON "calls" ("timestamp");`,
+	`CREATE INDEX IF NOT EXISTS "idx_calls_talkgroupId" ON "calls" ("talkgroupId");`,
+	`CREATE INDEX IF NOT EXISTS "idx_calls_audioPath" ON "calls" ("audioPath"(255));`,
 
 	`CREATE TABLE IF NOT EXISTS "callFrequencies" (
     "callFrequencyId" bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -138,6 +143,8 @@ var MysqlSchema = []string{
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
 
+	`CREATE INDEX IF NOT EXISTS "idx_callFrequencies_callId" ON "callFrequencies" ("callId");`,
+
 	`CREATE TABLE IF NOT EXISTS "callPatches" (
     "callPatchId" bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
     "callId" bigint NOT NULL,
@@ -145,6 +152,9 @@ var MysqlSchema = []string{
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY ("talkgroupId") REFERENCES "talkgroups" ("talkgroupId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_callPatches_callId" ON "callPatches" ("callId");`,
+	`CREATE INDEX IF NOT EXISTS "idx_callPatches_talkgroupId" ON "callPatches" ("talkgroupId");`,
 
 	`CREATE TABLE IF NOT EXISTS "callUnits" (
     "callUnitId" bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -154,12 +164,16 @@ var MysqlSchema = []string{
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
 
+	`CREATE INDEX IF NOT EXISTS "idx_callUnits_callId" ON "callUnits" ("callId");`,
+
 	`CREATE TABLE IF NOT EXISTS "delayed" (
     "delayedId" bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    "callID" bigint NOT NULL,
+    "callId" bigint NOT NULL,
     "timestamp" bigint NOT NULL,
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_delayed_callId" ON "delayed" ("callId");`,
 
 	`CREATE TABLE IF NOT EXISTS "dirwatches" (
     "dirwatchId" bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
@@ -183,6 +197,8 @@ var MysqlSchema = []string{
     "message" text NOT NULL,
     "timestamp" bigint NOT NULL
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_logs_timestamp" ON "logs" ("timestamp");`,
 
 	`CREATE TABLE IF NOT EXISTS "options" (
     "optionId" bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/server/postgresql.go
+++ b/server/postgresql.go
@@ -117,6 +117,7 @@ var PostgresqlSchema = []string{
     "audio" bytea NOT NULL,
     "audioFilename" text NOT NULL,
     "audioMime" text NOT NULL,
+    "audioPath" text NOT NULL DEFAULT '',
     "siteRef" integer NOT NULL DEFAULT 0,
     "systemId" bigint NOT NULL,
     "talkgroupId" bigint NOT NULL,
@@ -126,6 +127,10 @@ var PostgresqlSchema = []string{
   );`,
 
 	`CREATE INDEX IF NOT EXISTS "calls_idx" ON "calls" ("systemId","talkgroupId","siteRef","timestamp");`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_calls_timestamp" ON "calls" ("timestamp");`,
+	`CREATE INDEX IF NOT EXISTS "idx_calls_talkgroupId" ON "calls" ("talkgroupId");`,
+	`CREATE INDEX IF NOT EXISTS "idx_calls_audioPath" ON "calls" ("audioPath");`,
 
 	`CREATE TABLE IF NOT EXISTS "callFrequencies" (
     "callFrequencyId" bigserial NOT NULL PRIMARY KEY,
@@ -138,6 +143,8 @@ var PostgresqlSchema = []string{
     CONSTRAINT "callFrequencies_callId" FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
 
+	`CREATE INDEX IF NOT EXISTS "idx_callFrequencies_callId" ON "callFrequencies" ("callId");`,
+
 	`CREATE TABLE IF NOT EXISTS "callPatches" (
     "callPatchId" bigserial NOT NULL PRIMARY KEY,
     "callId" bigint NOT NULL,
@@ -145,6 +152,9 @@ var PostgresqlSchema = []string{
     CONSTRAINT "callPatches_callId" FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "callPatches_talkgroupId" FOREIGN KEY ("talkgroupId") REFERENCES "talkgroups" ("talkgroupId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_callPatches_callId" ON "callPatches" ("callId");`,
+	`CREATE INDEX IF NOT EXISTS "idx_callPatches_talkgroupId" ON "callPatches" ("talkgroupId");`,
 
 	`CREATE TABLE IF NOT EXISTS "callUnits" (
     "callUnitId" bigserial NOT NULL PRIMARY KEY,
@@ -154,12 +164,16 @@ var PostgresqlSchema = []string{
     CONSTRAINT "callUnits_callId" FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
 
+	`CREATE INDEX IF NOT EXISTS "idx_callUnits_callId" ON "callUnits" ("callId");`,
+
 	`CREATE TABLE IF NOT EXISTS "delayed" (
     "delayedId" bigserial NOT NULL PRIMARY KEY,
     "callId" bigint NOT NULL,
     "timestamp" bigint NOT NULL,
     CONSTRAINT "delayed_callId" FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_delayed_callId" ON "delayed" ("callId");`,
 
 	`CREATE TABLE IF NOT EXISTS "dirwatches" (
     "dirwatchId" bigserial NOT NULL PRIMARY KEY,
@@ -183,6 +197,8 @@ var PostgresqlSchema = []string{
     "message" text NOT NULL,
     "timestamp" bigint NOT NULL
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_logs_timestamp" ON "logs" ("timestamp");`,
 
 	`CREATE TABLE IF NOT EXISTS "options" (
     "optionId" bigserial NOT NULL PRIMARY KEY,

--- a/server/sqlite.go
+++ b/server/sqlite.go
@@ -117,6 +117,7 @@ var SqliteSchema = []string{
     "audio" blob NOT NULL,
     "audioFilename" text NOT NULL,
     "audioMime" text NOT NULL,
+    "audioPath" text NOT NULL DEFAULT '',
     "siteRef" integer NOT NULL DEFAULT 0,
     "systemId" integer NOT NULL,
     "talkgroupId" integer NOT NULL,
@@ -126,6 +127,10 @@ var SqliteSchema = []string{
   );`,
 
 	`CREATE INDEX IF NOT EXISTS "calls_idx" ON "calls" ("systemId","siteRef","talkgroupId","timestamp");`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_calls_timestamp" ON "calls" ("timestamp");`,
+	`CREATE INDEX IF NOT EXISTS "idx_calls_talkgroupId" ON "calls" ("talkgroupId");`,
+	`CREATE INDEX IF NOT EXISTS "idx_calls_audioPath" ON "calls" ("audioPath");`,
 
 	`CREATE TABLE IF NOT EXISTS "callFrequencies" (
     "callFrequencyId" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -138,6 +143,8 @@ var SqliteSchema = []string{
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
 
+	`CREATE INDEX IF NOT EXISTS "idx_callFrequencies_callId" ON "callFrequencies" ("callId");`,
+
 	`CREATE TABLE IF NOT EXISTS "callPatches" (
     "callPatchId" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
     "callId" integer NOT NULL,
@@ -145,6 +152,9 @@ var SqliteSchema = []string{
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY ("talkgroupId") REFERENCES "talkgroups" ("talkgroupId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_callPatches_callId" ON "callPatches" ("callId");`,
+	`CREATE INDEX IF NOT EXISTS "idx_callPatches_talkgroupId" ON "callPatches" ("talkgroupId");`,
 
 	`CREATE TABLE IF NOT EXISTS "callUnits" (
     "callUnitId" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -154,12 +164,16 @@ var SqliteSchema = []string{
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
 
+	`CREATE INDEX IF NOT EXISTS "idx_callUnits_callId" ON "callUnits" ("callId");`,
+
 	`CREATE TABLE IF NOT EXISTS "delayed" (
     "delayedId" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
     "callId" integer NOT NULL,
     "timestamp" integer NOT NULL,
     FOREIGN KEY ("callId") REFERENCES "calls" ("callId") ON DELETE CASCADE ON UPDATE CASCADE
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_delayed_callId" ON "delayed" ("callId");`,
 
 	`CREATE TABLE IF NOT EXISTS "dirwatches" (
     "dirwatchId" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -183,6 +197,8 @@ var SqliteSchema = []string{
     "message" text not null,
     "timestamp" integer not null
   );`,
+
+	`CREATE INDEX IF NOT EXISTS "idx_logs_timestamp" ON "logs" ("timestamp");`,
 
 	`CREATE TABLE IF NOT EXISTS "options" (
     "optionId" integer NOT NULL PRIMARY KEY AUTOINCREMENT,

--- a/server/system.go
+++ b/server/system.go
@@ -24,6 +24,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -486,12 +487,13 @@ func (systems *Systems) Read(db *Database) error {
 
 func (systems *Systems) Write(db *Database) error {
 	var (
-		err       error
-		query     string
-		res       sql.Result
-		rows      *sql.Rows
-		systemIds = []uint64{}
-		tx        *sql.Tx
+		err               error
+		query             string
+		res               sql.Result
+		rows              *sql.Rows
+		systemIds         = []uint64{}
+		tx                *sql.Tx
+		cascadeAudioPaths []string
 	)
 
 	systems.mutex.Lock()
@@ -536,6 +538,18 @@ func (systems *Systems) Write(db *Database) error {
 	if len(systemIds) > 0 {
 		if b, err := json.Marshal(systemIds); err == nil {
 			in := strings.ReplaceAll(strings.ReplaceAll(string(b), "[", "("), "]", ")")
+
+			// Capture audio file paths for call rows that will cascade-delete.
+			selectQuery := fmt.Sprintf(`SELECT "audioPath" FROM "calls" WHERE "systemId" IN %s AND "audioPath" <> ''`, in)
+			if pathRows, err := tx.Query(selectQuery); err == nil {
+				for pathRows.Next() {
+					var p sql.NullString
+					if err := pathRows.Scan(&p); err == nil && p.Valid && p.String != "" {
+						cascadeAudioPaths = append(cascadeAudioPaths, p.String)
+					}
+				}
+				pathRows.Close()
+			}
 
 			query = fmt.Sprintf(`DELETE FROM "systems" WHERE "systemId" IN %s`, in)
 			if res, err = tx.Exec(query); err != nil {
@@ -608,7 +622,10 @@ func (systems *Systems) Write(db *Database) error {
 			break
 		}
 
-		if err = system.Talkgroups.WriteTx(tx, system.Id, db.Config.DbType); err != nil {
+		tgPaths, tgErr := system.Talkgroups.WriteTx(tx, system.Id, db.Config.DbType)
+		cascadeAudioPaths = append(cascadeAudioPaths, tgPaths...)
+		if tgErr != nil {
+			err = tgErr
 			break
 		}
 
@@ -625,6 +642,12 @@ func (systems *Systems) Write(db *Database) error {
 	if err = tx.Commit(); err != nil {
 		tx.Rollback()
 		return formatError(err, "")
+	}
+
+	for _, p := range cascadeAudioPaths {
+		if rmErr := deleteAudioFile(p); rmErr != nil {
+			log.Println(formatError(rmErr, "cleanup"))
+		}
 	}
 
 	return nil

--- a/server/talkgroup.go
+++ b/server/talkgroup.go
@@ -287,7 +287,7 @@ func (talkgroups *Talkgroups) ReadTx(tx *sql.Tx, systemId uint64, dbType string)
 	return nil
 }
 
-func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string) error {
+func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string) ([]string, error) {
 	var (
 		err   error
 		query string
@@ -296,6 +296,7 @@ func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string
 
 		talkgroupGroupIds = []uint64{}
 		talkgroupIds      = []uint64{}
+		cascadeAudioPaths []string
 	)
 
 	talkgroups.mutex.Lock()
@@ -305,7 +306,7 @@ func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string
 
 	query = fmt.Sprintf(`SELECT "talkgroupId" FROM "talkgroups" WHERE "systemId" = %d`, systemId)
 	if rows, err = tx.Query(query); err != nil {
-		return formatError(err, query)
+		return nil, formatError(err, query)
 	}
 
 	for rows.Next() {
@@ -328,21 +329,33 @@ func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string
 	rows.Close()
 
 	if err != nil {
-		return formatError(err, "")
+		return nil, formatError(err, "")
 	}
 
 	if len(talkgroupIds) > 0 {
 		if b, err := json.Marshal(talkgroupIds); err == nil {
 			in := strings.ReplaceAll(strings.ReplaceAll(string(b), "[", "("), "]", ")")
 
+			// Capture audio file paths for cascading call rows before the DELETE.
+			selectQuery := fmt.Sprintf(`SELECT "audioPath" FROM "calls" WHERE "talkgroupId" IN %s AND "audioPath" <> ''`, in)
+			if pathRows, err := tx.Query(selectQuery); err == nil {
+				for pathRows.Next() {
+					var p sql.NullString
+					if err := pathRows.Scan(&p); err == nil && p.Valid && p.String != "" {
+						cascadeAudioPaths = append(cascadeAudioPaths, p.String)
+					}
+				}
+				pathRows.Close()
+			}
+
 			query = fmt.Sprintf(`DELETE FROM "talkgroups" WHERE "talkgroupId" IN %s`, in)
 			if _, err = tx.Exec(query); err != nil {
-				return formatError(err, query)
+				return nil, formatError(err, query)
 			}
 
 			query = fmt.Sprintf(`DELETE FROM "talkgroupGroups" WHERE "talkgroupId" IN %s`, in)
 			if _, err = tx.Exec(query); err != nil {
-				return formatError(err, query)
+				return cascadeAudioPaths, formatError(err, query)
 			}
 		}
 	}
@@ -412,7 +425,7 @@ func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string
 		rows.Close()
 
 		if err != nil {
-			return formatError(err, "")
+			return cascadeAudioPaths, formatError(err, "")
 		}
 
 		if len(talkgroupGroupIds) > 0 {
@@ -420,7 +433,7 @@ func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string
 				in := strings.ReplaceAll(strings.ReplaceAll(string(b), "[", "("), "]", ")")
 				query = fmt.Sprintf(`DELETE FROM "talkgroupGroups" WHERE "talkgroupGroupId" IN %s`, in)
 				if _, err = tx.Exec(query); err != nil {
-					return formatError(err, query)
+					return cascadeAudioPaths, formatError(err, query)
 				}
 			}
 		}
@@ -441,10 +454,10 @@ func (talkgroups *Talkgroups) WriteTx(tx *sql.Tx, systemId uint64, dbType string
 	}
 
 	if err != nil {
-		return formatError(err, query)
+		return cascadeAudioPaths, formatError(err, query)
 	}
 
-	return nil
+	return cascadeAudioPaths, nil
 }
 
 type TalkgroupsMap []TalkgroupMap


### PR DESCRIPTION
Create files on disk instead of in database, metadata stays in the database. 

update file cleanup to delete files on disk.

fix sql queries and add indexes to help with search. 

add migration for existing installs to get files out of the database and in to a folder structure. 

uses base_dir/audio to store audio