### PR TITLE
Add volume slider and scrub bar to the main listening page

### DIFF
--- a/client/src/app/components/rdio-scanner/main/main-sliders.scss
+++ b/client/src/app/components/rdio-scanner/main/main-sliders.scss
@@ -1,0 +1,166 @@
+// Scrub bar — sits inside the LCD display, styled to read as part of
+// the same surface. Track is recessed against the LCD background, thumb
+// has the same bevel as the .rdio-button family in common.scss.
+.rdio-scrub {
+  align-items: center;
+  display: flex;
+  height: 18px;
+  margin: 2px 4px 4px;
+
+  .rdio-scrub-input {
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    cursor: pointer;
+    flex: 1;
+    height: 18px;
+    margin: 0;
+    outline: none;
+    padding: 0;
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.4;
+    }
+
+    // Track — recessed inset on the LCD-green background.
+    &::-webkit-slider-runnable-track {
+      background: rgba(0, 0, 0, 0.25);
+      border-radius: 2px;
+      box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.5),
+        inset -1px -1px 1px rgba(255, 255, 255, 0.2);
+      height: 4px;
+    }
+    &::-moz-range-track {
+      background: rgba(0, 0, 0, 0.25);
+      border-radius: 2px;
+      box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.5),
+        inset -1px -1px 1px rgba(255, 255, 255, 0.2);
+      height: 4px;
+    }
+
+    // Thumb — beveled dark cap matching .rdio-button.
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      background: rgb(45, 45, 45);
+      border: none;
+      border-radius: 50%;
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.3) inset,
+        0 0 2px rgba(0, 0, 0, 0.5);
+      cursor: pointer;
+      height: 14px;
+      margin-top: -5px;
+      width: 14px;
+    }
+    &::-moz-range-thumb {
+      background: rgb(45, 45, 45);
+      border: none;
+      border-radius: 50%;
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.3) inset,
+        0 0 2px rgba(0, 0, 0, 0.5);
+      cursor: pointer;
+      height: 14px;
+      width: 14px;
+    }
+
+    &:focus-visible::-webkit-slider-thumb {
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.3) inset,
+        0 0 4px rgb(0, 230, 118);
+    }
+    &:focus-visible::-moz-range-thumb {
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.3) inset,
+        0 0 4px rgb(0, 230, 118);
+    }
+  }
+}
+
+// Volume row — flat strip between the LCD and the control button cluster.
+// Speaker icons sit at the ends; the slider track is recessed into the
+// outer panel color (rgb(45, 45, 45)) instead of the LCD green.
+.rdio-volume {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding: 0 4px;
+
+  .rdio-volume-icon {
+    color: rgb(64, 64, 64);
+    font-size: 20px;
+    height: 20px;
+    width: 20px;
+  }
+
+  .rdio-volume-input {
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    cursor: pointer;
+    flex: 1;
+    height: 20px;
+    margin: 0;
+    outline: none;
+    padding: 0;
+
+    &::-webkit-slider-runnable-track {
+      background: rgb(28, 28, 28);
+      border-radius: 3px;
+      box-shadow: inset 1px 1px 3px rgba(0, 0, 0, 0.8),
+        inset -1px -1px 1px rgba(255, 255, 255, 0.1),
+        0 1px 0 rgba(255, 255, 255, 0.15);
+      height: 6px;
+    }
+    &::-moz-range-track {
+      background: rgb(28, 28, 28);
+      border-radius: 3px;
+      box-shadow: inset 1px 1px 3px rgba(0, 0, 0, 0.8),
+        inset -1px -1px 1px rgba(255, 255, 255, 0.1),
+        0 1px 0 rgba(255, 255, 255, 0.15);
+      height: 6px;
+    }
+
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      background: linear-gradient(180deg, rgb(80, 80, 80), rgb(40, 40, 40));
+      border: none;
+      border-radius: 3px;
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.4) inset,
+        0 1px 2px rgba(0, 0, 0, 0.6);
+      cursor: pointer;
+      height: 18px;
+      margin-top: -6px;
+      width: 22px;
+    }
+    &::-moz-range-thumb {
+      background: linear-gradient(180deg, rgb(80, 80, 80), rgb(40, 40, 40));
+      border: none;
+      border-radius: 3px;
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.4) inset,
+        0 1px 2px rgba(0, 0, 0, 0.6);
+      cursor: pointer;
+      height: 18px;
+      width: 22px;
+    }
+
+    &:focus-visible::-webkit-slider-thumb {
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.4) inset,
+        0 0 6px rgb(0, 230, 118);
+    }
+    &:focus-visible::-moz-range-thumb {
+      box-shadow: -1px -1px 1px rgba(0, 0, 0, 0.7) inset,
+        1px 1px 1px rgba(255, 255, 255, 0.4) inset,
+        0 0 6px rgb(0, 230, 118);
+    }
+  }
+}
+

--- a/client/src/app/components/rdio-scanner/main/main.component.html
+++ b/client/src/app/components/rdio-scanner/main/main.component.html
@@ -44,6 +44,14 @@
   <div class="row big full">
     <span>{{ callTalkgroupName }}</span>
   </div>
+  <div class="rdio-scrub">
+    <input type="range" class="rdio-scrub-input"
+      min="0" [max]="callDuration || 1" step="0.1"
+      [disabled]="!call || !callDuration"
+      [value]="callTime"
+      (input)="onScrub($event)"
+      aria-label="Playback position">
+  </div>
   <div class="row">
     <div>
       <span>F: {{ callFrequency || 0 }}</span>
@@ -141,6 +149,15 @@
       </tbody>
     </table>
   </div>
+</div>
+<div class="rdio-volume">
+  <mat-icon class="rdio-volume-icon" aria-hidden="true">volume_down</mat-icon>
+  <input type="range" class="rdio-volume-input"
+    min="0" max="1" step="0.01"
+    [value]="volume"
+    (input)="onVolumeChange($event)"
+    aria-label="Volume">
+  <mat-icon class="rdio-volume-icon" aria-hidden="true">volume_up</mat-icon>
 </div>
 <div class="rdio-control">
   <div class="row">

--- a/client/src/app/components/rdio-scanner/main/main.component.ts
+++ b/client/src/app/components/rdio-scanner/main/main.component.ts
@@ -17,7 +17,7 @@
  * ****************************************************************************
  */
 
-import { ChangeDetectorRef, Component, EventEmitter, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, HostListener, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatInput } from '@angular/material/input';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -40,6 +40,7 @@ import { RdioScannerSupportComponent } from './support/support.component';
     styleUrls: [
         '../common.scss',
         './main.component.scss',
+        './main-sliders.scss',
     ],
     templateUrl: './main.component.html',
     standalone: false
@@ -80,6 +81,7 @@ export class RdioScannerMainComponent implements OnDestroy, OnInit {
     // END OF RED TAPE.
     //
 
+    callDuration = 0;
     callTime = 0;
     callUnit = '0';
 
@@ -119,6 +121,11 @@ export class RdioScannerMainComponent implements OnDestroy, OnInit {
 
     type = '';
 
+    // Mirrored from RdioScannerService.getVolume() so the slider's [value]
+    // binding stays reactive when the service emits a volume event (for
+    // instance after the initial load from localStorage).
+    volume = 1;
+
     get showListenersCount(): boolean {
         return this.config?.showListenersCount || false;
     }
@@ -152,6 +159,87 @@ export class RdioScannerMainComponent implements OnDestroy, OnInit {
         });
 
         this.eventSubscription = this.rdioScannerService.event.subscribe((event: RdioScannerEvent) => this.eventHandler(event));
+
+        // Pull the persisted volume (localStorage) so the slider thumb is
+        // positioned correctly on first paint.
+        this.volume = this.rdioScannerService.getVolume();
+    }
+
+    onScrub(ev: Event): void {
+        const v = parseFloat((ev.target as HTMLInputElement).value);
+        if (!isNaN(v)) {
+            this.rdioScannerService.seek(v);
+        }
+    }
+
+    onVolumeChange(ev: Event): void {
+        const v = parseFloat((ev.target as HTMLInputElement).value);
+        if (!isNaN(v)) {
+            this.volume = v;
+            this.rdioScannerService.setVolume(v);
+        }
+    }
+
+    // mutedAt holds the pre-mute volume so M can toggle back. 0 means
+    // either "we just unmuted from M" or "volume was always zero" — in
+    // both cases the next M press restores to a sensible 0.5.
+    private mutedAt = 0;
+
+    @HostListener('document:keydown', ['$event'])
+    onGlobalKey(ev: KeyboardEvent): void {
+        // Don't hijack keys while the user is typing into an input,
+        // textarea, or contenteditable element. Notable side-effect:
+        // when the scrub or volume slider has focus, the browser's
+        // native range-input ←/→ stepping still works (with the input's
+        // own `step`), which is what we want.
+        const t = ev.target as HTMLElement | null;
+        if (t) {
+            const tag = t.tagName;
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || t.isContentEditable) {
+                return;
+            }
+        }
+        if (ev.ctrlKey || ev.metaKey || ev.altKey) {
+            return;
+        }
+
+        switch (ev.key) {
+            case ' ':
+            case 'Spacebar':
+                this.pause();
+                ev.preventDefault();
+                break;
+            case 'ArrowLeft':
+                if (this.call && this.callDuration > 0) {
+                    this.rdioScannerService.seek(Math.max(0, this.callTime - 5));
+                    ev.preventDefault();
+                }
+                break;
+            case 'ArrowRight':
+                if (this.call && this.callDuration > 0) {
+                    this.rdioScannerService.seek(Math.min(this.callDuration, this.callTime + 5));
+                    ev.preventDefault();
+                }
+                break;
+            case 'ArrowUp':
+                this.rdioScannerService.setVolume(Math.min(1, this.volume + 0.05));
+                ev.preventDefault();
+                break;
+            case 'ArrowDown':
+                this.rdioScannerService.setVolume(Math.max(0, this.volume - 0.05));
+                ev.preventDefault();
+                break;
+            case 'm':
+            case 'M':
+                if (this.volume > 0) {
+                    this.mutedAt = this.volume;
+                    this.rdioScannerService.setVolume(0);
+                } else {
+                    this.rdioScannerService.setVolume(this.mutedAt > 0 ? this.mutedAt : 0.5);
+                }
+                ev.preventDefault();
+                break;
+        }
     }
 
     authenticate(password = this.authForm.get('password')?.value): void {
@@ -411,7 +499,20 @@ export class RdioScannerMainComponent implements OnDestroy, OnInit {
                 this.call = event.call;
 
                 this.updateDimmer();
+            } else {
+                // No call is playing — reset scrub bar so the thumb
+                // doesn't show a stale position from the previous clip.
+                this.callDuration = 0;
+                this.callTime = 0;
             }
+        }
+
+        if ('duration' in event && typeof event.duration === 'number') {
+            this.callDuration = event.duration;
+        }
+
+        if ('volume' in event && typeof event.volume === 'number') {
+            this.volume = event.volume;
         }
 
         if ('config' in event) {

--- a/client/src/app/components/rdio-scanner/rdio-scanner.service.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.service.ts
@@ -68,13 +68,28 @@ export class RdioScannerService implements OnDestroy {
     static LOCAL_STORAGE_KEY_LEGACY = 'rdio-scanner';
     static LOCAL_STORAGE_KEY_LFM = 'rdio-scanner-lfm';
     static LOCAL_STORAGE_KEY_PIN = 'rdio-scanner-pin';
+    static LOCAL_STORAGE_KEY_VOLUME = 'rdio-scanner-volume';
 
     event = new EventEmitter<RdioScannerEvent>();
 
     private audioContext: AudioContext | undefined;
 
+    // audioGain sits between every source and destination so volume can be
+    // adjusted live. It's created lazily during bootstrapAudio() once the
+    // AudioContext is available.
+    private audioGain: GainNode | undefined;
+
     private audioSource: AudioBufferSourceNode | undefined;
     private audioSourceStartTime = NaN;
+
+    // audioBuffer holds the decoded buffer for the currently-playing call,
+    // kept so seek() can construct a fresh BufferSourceNode at an arbitrary
+    // offset without re-decoding the audio bytes.
+    private audioBuffer: AudioBuffer | undefined;
+
+    // currentVolume is the linear gain (0..1) applied to audioGain. Updated
+    // by setVolume() and persisted to localStorage.
+    private currentVolume = 1.0;
 
     private call: RdioScannerCall | undefined;
     private callPrevious: RdioScannerCall | undefined;
@@ -128,6 +143,8 @@ export class RdioScannerService implements OnDestroy {
             return;
         }
 
+        this.readStoredVolume();
+
         this.bootstrapAudio();
 
         this.initializeInstanceId();
@@ -135,6 +152,21 @@ export class RdioScannerService implements OnDestroy {
         this.readLivefeedMap();
 
         this.openWebsocket();
+    }
+
+    private readStoredVolume(): void {
+        try {
+            const raw = window?.localStorage?.getItem(RdioScannerService.LOCAL_STORAGE_KEY_VOLUME);
+            if (raw === null || raw === undefined) {
+                return;
+            }
+            const v = parseFloat(raw);
+            if (!isNaN(v)) {
+                this.currentVolume = Math.min(1, Math.max(0, v));
+            }
+        } catch {
+            // localStorage may be unavailable (private browsing, etc.); fall back to default.
+        }
     }
 
     authenticate(password: string): void {
@@ -440,6 +472,68 @@ export class RdioScannerService implements OnDestroy {
         this.event.emit({ pause: this.livefeedPaused });
     }
 
+    // setVolume clamps to [0, 1] and ramps the gain node a few ms to avoid
+    // audible clicks (a direct value assignment on AudioParam produces a
+    // step change that can pop on transient-rich content). The new value is
+    // persisted to localStorage so it survives reloads.
+    setVolume(v: number): void {
+        v = Math.min(1, Math.max(0, v));
+        this.currentVolume = v;
+        if (this.audioGain && this.audioContext) {
+            this.audioGain.gain.setTargetAtTime(v, this.audioContext.currentTime, 0.01);
+        }
+        try {
+            window?.localStorage?.setItem(RdioScannerService.LOCAL_STORAGE_KEY_VOLUME, String(v));
+        } catch {
+            // localStorage may be unavailable in private browsing; non-fatal.
+        }
+        this.event.emit({ volume: v });
+    }
+
+    getVolume(): number {
+        return this.currentVolume;
+    }
+
+    getCurrentCallDuration(): number {
+        return this.audioBuffer?.duration ?? 0;
+    }
+
+    // seek jumps playback to offsetSeconds within the current call. The
+    // AudioBufferSourceNode API is one-shot: to seek we have to tear down
+    // the current source and start a fresh one with the desired offset.
+    // The decoded buffer is reused so this happens in sub-ms with no
+    // network or decode cost.
+    seek(offsetSeconds: number): void {
+        if (!this.audioContext || !this.audioBuffer || !this.audioGain || !this.call) {
+            return;
+        }
+
+        const duration = this.audioBuffer.duration;
+        const target = Math.min(duration, Math.max(0, offsetSeconds));
+
+        if (this.audioSource) {
+            this.audioSource.onended = null;
+            try {
+                this.audioSource.stop();
+            } catch {
+                // Source may already have ended; safe to ignore.
+            }
+            this.audioSource.disconnect();
+            this.audioSource = undefined;
+        }
+
+        this.audioSource = this.audioContext.createBufferSource();
+        this.audioSource.buffer = this.audioBuffer;
+        this.audioSource.connect(this.audioGain);
+        this.audioSource.onended = () => this.skip({ delay: true });
+        this.audioSource.start(0, target);
+
+        // Shift the perceived start time so the `time` event-emitter
+        // (currentTime - startTime) keeps producing the right offset.
+        this.audioSourceStartTime = this.audioContext.currentTime - target;
+        this.event.emit({ time: target });
+    }
+
     play(call?: RdioScannerCall | undefined): void {
         if (this.livefeedPaused || this.skipDelay) {
             return;
@@ -474,19 +568,22 @@ export class RdioScannerService implements OnDestroy {
         }
 
         this.audioContext?.decodeAudioData(arrayBuffer, async (buffer) => {
-            if (!this.audioContext || this.audioSource || !this.call) {
+            if (!this.audioContext || !this.audioGain || this.audioSource || !this.call) {
                 return;
             }
 
             await this.playAlert(this.call);
 
+            this.audioBuffer = buffer;
             this.audioSource = this.audioContext.createBufferSource();
             this.audioSource.buffer = buffer;
-            this.audioSource.connect(this.audioContext.destination);
+            this.audioSource.connect(this.audioGain);
             this.audioSource.onended = () => this.skip({ delay: true });
             this.audioSource.start();
 
-            this.event.emit({ call: this.call, queue });
+            // Emit duration so the UI can size its scrub bar before the first
+            // time-tick fires.
+            this.event.emit({ call: this.call, duration: buffer.duration, queue });
 
             interval(500).pipe(takeWhile(() => !!this.call)).subscribe(() => {
                 if (this.audioContext && !isNaN(this.audioContext.currentTime)) {
@@ -601,6 +698,8 @@ export class RdioScannerService implements OnDestroy {
             this.audioSourceStartTime = NaN;
         }
 
+        this.audioBuffer = undefined;
+
         if (this.call) {
             this.callPrevious = this.call;
 
@@ -700,6 +799,15 @@ export class RdioScannerService implements OnDestroy {
         const bootstrap = async () => {
             if (!this.audioContext) {
                 this.audioContext = new (window.AudioContext || window.webkitAudioContext)({ latencyHint: 'playback' });
+            }
+
+            // The gain node lives for the lifetime of the AudioContext.
+            // Every play() / seek() connects its source through this node so
+            // setVolume() takes effect without rebuilding the graph.
+            if (!this.audioGain && this.audioContext) {
+                this.audioGain = this.audioContext.createGain();
+                this.audioGain.gain.value = this.currentVolume;
+                this.audioGain.connect(this.audioContext.destination);
             }
 
             if (!this.oscillatorContext) {

--- a/client/src/app/components/rdio-scanner/rdio-scanner.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.ts
@@ -113,6 +113,7 @@ export interface RdioScannerEvent {
     categories?: RdioScannerCategory[];
     call?: RdioScannerCall;
     config?: RdioScannerConfig;
+    duration?: number;
     expired?: boolean;
     holdSys?: boolean;
     holdTg?: boolean;
@@ -126,6 +127,7 @@ export interface RdioScannerEvent {
     queue?: number;
     time?: number;
     tooMany?: boolean;
+    volume?: number;
 }
 
 export interface RdioScannerGroupData {


### PR DESCRIPTION
## Summary

Adds two new playback controls to the main listening page that didn't exist before: a **volume slider** and a **scrub bar** (draggable playback-position indicator). Both are hand-rolled `<input type=\"range\">` elements styled to match the existing scanner-radio aesthetic — recessed dark tracks, beveled thumbs, accent-green focus glow. No Material slider component is introduced; the controls visually read as part of the same panel.

Also: keyboard shortcuts (Space, ←/→, ↑/↓, M).

## Layout (where the new controls land)

```
┌──────────────────────────────────────────┐
│ STATUS BAR (branding + LED indicator)    │
├──────────────────────────────────────────┤
│  ╔══════ LCD DISPLAY ═══════════════════╗ │
│  ║ system / talkgroup / unit metadata  ║ │
│  ║                                     ║ │
│  ║  talkgroup name             02:14   ║ │   ← existing progress text
│  ║  ━━━━━━━━━●─────────────────────    ║ │   ← NEW: scrub bar inside LCD
│  ║ history table                       ║ │
│  ╚═════════════════════════════════════╝ │
├──────────────────────────────────────────┤
│ 🔉  ──●────────────────────────  🔊      │   ← NEW: volume row
├──────────────────────────────────────────┤
│ [▶ PLAY] [⏸ PAUSE] [⏭ SKIP] [LIVE] [PIN] │   ← existing buttons
└──────────────────────────────────────────┘
```

## Implementation highlights

- **Audio graph rewired**: `source → GainNode → destination`. The GainNode is created once in `bootstrapAudio()` and reused across all calls so volume changes never rebuild the graph. `setVolume()` uses `AudioParam.setTargetAtTime` for a 10 ms ramp instead of a hard step, avoiding the audible click that a direct `.value =` assignment produces.
- **Seek is real**: `AudioBufferSourceNode` is one-shot, so seek means stop → disconnect → new source → `start(0, offset)`. The decoded buffer is held in memory only while the call is active, so seek is O(1) — no decode, no network. `audioSourceStartTime` is adjusted so the existing time-emitter keeps producing accurate offsets after a seek.
- **Volume persists across reloads** via `localStorage` (`rdio-scanner-volume`). Wrapped in try/catch so private-browsing mode degrades gracefully.
- **Keyboard shortcuts**:
  - `Space` — play/pause
  - `←` / `→` — seek ±5 s within the current call
  - `↑` / `↓` — volume ±5 %
  - `M` — mute / restore previous volume
  - Ignored when focus is on an `<input>`, `<textarea>`, or contenteditable, and when modifier keys are held. The scrub slider's native range-input stepping (←/→ at step=0.1) still works when it has focus.
- **No conflicts checked**: only existing `@HostListener` is `window:beforeunload`; Live Feed is button-driven. The recon was clean before shortcuts were added.

## Files

- `client/src/app/components/rdio-scanner/main/main.component.html` — insert scrub bar inside LCD; volume row between LCD and controls
- `client/src/app/components/rdio-scanner/main/main.component.ts` — new state (`callDuration`, `volume`), handlers (`onScrub`, `onVolumeChange`, keyboard), event-handler additions
- `client/src/app/components/rdio-scanner/main/main-sliders.scss` (new file) — all slider styling, in its own SCSS so `main.component.scss` stays under Angular's 5 KB per-component-style budget
- `client/src/app/components/rdio-scanner/rdio-scanner.service.ts` — GainNode wiring, `setVolume`, `getVolume`, `seek`, `getCurrentCallDuration`, `readStoredVolume`; play() now connects source through the gain node and emits `duration`
- `client/src/app/components/rdio-scanner/rdio-scanner.ts` — `duration?: number; volume?: number;` added to `RdioScannerEvent`

## Test plan

- [x] `npm run build` (production) — clean, 8 s, no warnings; main bundle grew ~1 KB
- [ ] `npm run serve` and verify in a browser:
  - [ ] Scrub bar updates as a call plays; thumb position matches elapsed time
  - [ ] Dragging the scrub bar mid-call jumps audio to the new position
  - [ ] Volume slider attenuates audio audibly across its range without clicks
  - [ ] Volume persists across a page reload
  - [ ] Space toggles pause; ←/→ seek; ↑/↓ adjust volume; M mutes/restores
  - [ ] Typing in the PIN input doesn't trigger shortcuts
- [ ] No audible click when adjusting volume during loud content
- [ ] Accessibility: scrub bar and volume input keyboard-navigable; focus ring visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)