### PR TITLE
archive: date range, free-text search, ?call deep links, higher-res w…

### DIFF
--- a/client/src/app/components/rdio-scanner/main/main.component.ts
+++ b/client/src/app/components/rdio-scanner/main/main.component.ts
@@ -579,7 +579,11 @@ export class RdioScannerMainComponent implements OnDestroy, OnInit {
         }
 
         if ('peaks' in event && Array.isArray(event.peaks)) {
-            this.peaks = event.peaks;
+            // Service now emits a high-res (~1024) peak array sized for
+            // the search dock's canvas ribbon. The drawer's SVG bar
+            // template assumes 64 bars (viewBox 0 0 64 30) — keep that
+            // layout by max-pool downsampling to bar count here.
+            this.peaks = this.downsamplePeaks(event.peaks, 64);
         }
 
         if ('volume' in event && typeof event.volume === 'number') {
@@ -672,6 +676,26 @@ export class RdioScannerMainComponent implements OnDestroy, OnInit {
 
     private formatAfs(n: number): string {
         return `${(n >> 7 & 15).toString().padStart(2, '0')}-${(n >> 3 & 15).toString().padStart(2, '0')}${n & 7}`;
+    }
+
+    // Max-pool downsample a peak array to `n` buckets. Used to keep the
+    // drawer's SVG bar template at its expected 64-bar geometry while
+    // the service emits a much higher-res array for the search dock's
+    // canvas ribbon. No-op if src already has <= n entries.
+    private downsamplePeaks(src: number[], n: number): number[] {
+        if (src.length <= n) return src;
+        const out = new Array<number>(n);
+        const step = src.length / n;
+        for (let i = 0; i < n; i++) {
+            const from = Math.floor(i * step);
+            const to = Math.max(from + 1, Math.floor((i + 1) * step));
+            let peak = 0;
+            for (let j = from; j < to && j < src.length; j++) {
+                if (src[j] > peak) peak = src[j];
+            }
+            out[i] = peak;
+        }
+        return out;
     }
 
     private formatFrequency(frequency: number | undefined): string {

--- a/client/src/app/components/rdio-scanner/rdio-scanner.component.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.component.ts
@@ -24,6 +24,7 @@ import { timer } from 'rxjs';
 import { RdioScannerEvent, RdioScannerLivefeedMode } from './rdio-scanner';
 import { RdioScannerService } from './rdio-scanner.service';
 import { RdioScannerNativeComponent } from './native/native.component';
+import { RdioScannerSearchComponent } from './search/search.component';
 
 @Component({
     selector: 'rdio-scanner',
@@ -40,11 +41,34 @@ export class RdioScannerComponent implements OnDestroy, OnInit {
 
     @ViewChild('selectPanel') private selectPanel: MatSidenav | undefined;
 
+    @ViewChild('searchComponent') private searchComponent: RdioScannerSearchComponent | undefined;
+
+    /** Holds a `?call=<id>` deep-link target between page load and the
+     *  first post-auth `config` event. Restricted instances will not
+     *  emit `config` until the user submits a valid PIN, so this is
+     *  naturally gated behind the same auth wall as everything else —
+     *  no separate authorization check needed here. */
+    private pendingDeepLinkCallId: number | undefined;
+
     constructor(
         private matSnackBar: MatSnackBar,
         private ngElementRef: ElementRef,
         private rdioScannerService: RdioScannerService,
     ) {
+        // Parse the deep-link id eagerly (constructor is the earliest
+        // point at which window is reliable). Holding it in memory until
+        // `config` arrives means any websocket re-handshake or PIN retry
+        // re-triggers the same code path automatically.
+        try {
+            const url = new URL(window.location.href);
+            const raw = url.searchParams.get('call');
+            if (raw && /^\d+$/.test(raw)) {
+                this.pendingDeepLinkCallId = parseInt(raw, 10);
+            }
+        } catch {
+            // URL parsing failed — nothing to consume.
+        }
+
         this.eventSubscription = this.rdioScannerService.event.subscribe((event: RdioScannerEvent) => this.eventHandler(event));
     }
 
@@ -142,6 +166,31 @@ export class RdioScannerComponent implements OnDestroy, OnInit {
     private eventHandler(event: RdioScannerEvent): void {
         if (event.livefeedMode) {
             this.livefeedMode = event.livefeedMode;
+        }
+
+        // The server only emits Config after successful PIN auth on
+        // restricted instances (and immediately on unrestricted ones),
+        // so consuming the deep-link here transparently enforces the
+        // access-code gate.
+        if ('config' in event && this.pendingDeepLinkCallId !== undefined) {
+            const id = this.pendingDeepLinkCallId;
+            this.pendingDeepLinkCallId = undefined;
+            this.consumeDeepLink(id);
+        }
+    }
+
+    private consumeDeepLink(callId: number): void {
+        // Open the search panel so the user can see the loaded call in
+        // context. Even if the call isn't on page 1 of the result list,
+        // the dock player at the bottom reflects it immediately.
+        this.searchPanel?.open();
+        this.searchComponent?.searchCalls();
+        this.rdioScannerService.loadAndPlay(callId);
+
+        // Strip ?call=… so a refresh doesn't re-trigger and the URL
+        // settles to the canonical app path. Keeps existing hash.
+        if (window.history && typeof window.history.replaceState === 'function') {
+            window.history.replaceState({}, '', window.location.pathname + window.location.hash);
         }
     }
 }

--- a/client/src/app/components/rdio-scanner/rdio-scanner.service.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.service.ts
@@ -633,16 +633,16 @@ export class RdioScannerService implements OnDestroy {
         this.event.emit({ time: target });
     }
 
-    // computePeaks reduces a decoded AudioBuffer to a small array of peak
-    // amplitudes for the scrub-bar waveform. Channel 0 only (mono read of
-    // whatever the source provides), bucketed into ~buckets equal-width
-    // slices, each slice's max |sample| in [0, 1]. Returns a plain number[]
-    // so it survives JSON-ish event propagation and Angular change detection.
+    // computePeaks reduces a decoded AudioBuffer to a peak-amplitude array
+    // for the scrub-bar waveform. Channel 0 only, bucketed into `buckets`
+    // equal-width slices, each slice's max |sample| in [0, 1]. Returns a
+    // plain number[] so it survives event propagation + change detection.
     //
-    // Default bucket count chosen so bars render around a 60/40 fill ratio
-    // on typical scrub widths (~250–350 px), matching wavesurfer-style
-    // proportions without looking dense on mobile.
-    private computePeaks(buffer: AudioBuffer, buckets = 64): number[] {
+    // The default is sized for the search dock's high-res canvas ribbon
+    // renderer (one peak per output pixel on most desktop widths). The
+    // main-view drawer down-samples to its own bar count (~64) before
+    // render so its SVG bar layout doesn't change.
+    private computePeaks(buffer: AudioBuffer, buckets = 1024): number[] {
         const data = buffer.getChannelData(0);
         const step = Math.max(1, Math.floor(data.length / buckets));
         const out = new Array<number>(buckets);

--- a/client/src/app/components/rdio-scanner/rdio-scanner.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.ts
@@ -178,10 +178,15 @@ export interface RdioScannerPlaybackList {
 }
 
 export interface RdioScannerSearchOptions {
+    // Legacy single-date filter — kept for compatibility. New code should
+    // use dateStart/dateEnd for a real range.
     date?: Date;
+    dateStart?: Date;
+    dateEnd?: Date;
     group?: string;
     limit: number;
     offset: number;
+    query?: string;
     sort: number;
     system?: number;
     tag?: string;

--- a/client/src/app/components/rdio-scanner/search/search-cards-dock.scss
+++ b/client/src/app/components/rdio-scanner/search/search-cards-dock.scss
@@ -27,6 +27,7 @@ $accent: rgb(0, 230, 118);
   padding: 8px 12px;
 }
 .results-count { color: rgb(180, 180, 180); font-size: 12px; }
+.results-context { color: rgb(120, 120, 120); margin-left: 4px; }
 .results-loading { color: $accent; font-size: 11px; letter-spacing: 0.5px; text-transform: uppercase; }
 .results-spacer { flex: 1; }
 .sidebar-toggle { display: none; }
@@ -174,7 +175,7 @@ $accent: rgb(0, 230, 118);
   gap: 12px;
   grid-column: 1 / 3;
   grid-row: 2;
-  grid-template-columns: 40px 200px 1fr auto auto auto;
+  grid-template-columns: 40px 200px 1fr auto auto auto auto;
   padding: 14px 16px;
 }
 .dock-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
@@ -257,4 +258,5 @@ $accent: rgb(0, 230, 118);
   .dock-seek { grid-column: 1 / 4; grid-row: 2; }
   .dock-timecode { display: none; }
   .dock-autoplay .dock-autoplay-label { display: none; }
+  .dock-permalink { display: none; }
 }

--- a/client/src/app/components/rdio-scanner/search/search.component.html
+++ b/client/src/app/components/rdio-scanner/search/search.component.html
@@ -23,7 +23,7 @@
         <h3>Search</h3>
         <div class="field">
           <input type="search" placeholder="Talkgroup, unit, frequency…"
-            formControlName="query" (input)="formChangeHandler()">
+            formControlName="query">
         </div>
 
         <h3>Filters</h3>
@@ -69,10 +69,16 @@
             (change)="formChangeHandler()">
         </div>
         <div class="field">
-          <label>Date</label>
-          <input type="datetime-local" formControlName="date"
+          <label>From</label>
+          <input type="datetime-local" formControlName="dateStart"
             [max]="playbackList?.dateStop" [min]="playbackList?.dateStart"
-            (change)="formChangeHandler()">
+            (change)="onDateChange()">
+        </div>
+        <div class="field">
+          <label>To</label>
+          <input type="datetime-local" formControlName="dateEnd"
+            [max]="playbackList?.dateStop" [min]="playbackList?.dateStart"
+            (change)="onDateChange()">
         </div>
         <div class="field">
           <label>Sort</label>
@@ -102,6 +108,9 @@
       <span class="results-count">
         @if (playbackList) {
           {{ playbackList.count }} result{{ playbackList.count === 1 ? '' : 's' }}
+          @if (contextSystemLabel(); as sysLabel) {
+            <span class="results-context">· {{ sysLabel }}</span>
+          }
         } @else {
           Loading…
         }
@@ -132,20 +141,25 @@
     </div>
 
     <div class="results-scroll" #scrollableResults>
-      @if (results | async; as rows) {
-        @for (row of rows; track row?.id; let i = $index) {
-          @if (row) {
+      @if (displayItems | async; as items) {
+        @for (item of items; track item.key) {
+          @if (item.kind === 'header') {
+            <div class="date-header">
+              <span class="date-label">{{ item.label }}</span>
+              <span class="date-count">{{ item.count }} on page</span>
+            </div>
+          } @else if (item.call) {
             <div class="result-card"
-              [class.playing]="row.id === call?.id"
-              (click)="play(+row.id)">
+              [class.playing]="item.call.id === call?.id"
+              (click)="play(+item.call.id)">
               <button type="button" class="btn-play"
-                (click)="$event.stopPropagation(); rowAction(row)"
-                [attr.aria-label]="rowActionLabel(row)">
-                @if (row.id === callPending) {
+                (click)="$event.stopPropagation(); rowAction(item.call)"
+                [attr.aria-label]="rowActionLabel(item.call)">
+                @if (item.call.id === callPending) {
                   <mat-icon class="spin">cached</mat-icon>
-                } @else if (row.id === call?.id && !paused) {
+                } @else if (item.call.id === call?.id && !paused) {
                   <mat-icon>pause</mat-icon>
-                } @else if (row.id === call?.id && paused) {
+                } @else if (item.call.id === call?.id && paused) {
                   <mat-icon>play_arrow</mat-icon>
                 } @else {
                   <mat-icon>play_arrow</mat-icon>
@@ -154,25 +168,24 @@
               <div class="meta">
                 <div class="row1">
                   <span class="tg">
-                    {{ row.talkgroupData?.label || row.talkgroup }}
+                    {{ item.call.talkgroupData?.label || item.call.talkgroup }}
                   </span>
-                  @if (row.talkgroupData?.tag) {
-                    <span class="tg-tag">{{ row.talkgroupData?.tag }}</span>
+                  @if (item.call.talkgroupData?.tag) {
+                    <span class="tg-tag">{{ item.call.talkgroupData?.tag }}</span>
                   }
                 </div>
                 <div class="row2">
                   <span class="time">
-                    {{ row.dateTime | date:'MM/dd' }} ·
-                    {{ row.dateTime | date: time12h ? 'h:mm:ss a' : 'HH:mm:ss' }}
+                    {{ item.call.dateTime | date: time12h ? 'h:mm:ss a' : 'HH:mm:ss' }}
                   </span>
-                  <span class="sys">{{ row.systemData?.label || row.system }}</span>
-                  @if (row.talkgroupData?.name && row.talkgroupData?.name !== row.talkgroupData?.label) {
-                    <span class="tg-name">{{ row.talkgroupData?.name }}</span>
+                  <span class="sys">{{ item.call.systemData?.label || item.call.system }}</span>
+                  @if (item.call.talkgroupData?.name && item.call.talkgroupData?.name !== item.call.talkgroupData?.label) {
+                    <span class="tg-name">{{ item.call.talkgroupData?.name }}</span>
                   }
                 </div>
               </div>
               <button type="button" class="icon-btn subtle dl"
-                (click)="$event.stopPropagation(); download(+row.id)"
+                (click)="$event.stopPropagation(); download(+item.call.id)"
                 aria-label="Download">
                 <mat-icon>save_alt</mat-icon>
               </button>
@@ -181,7 +194,7 @@
             <div class="result-card skeleton"></div>
           }
         }
-        @if (!rows.length && !resultsPending) {
+        @if (!items.length && !resultsPending) {
           <div class="empty-state">No calls match the current filters.</div>
         }
       }
@@ -228,6 +241,11 @@
     <button type="button" class="icon-btn subtle"
       [disabled]="!call" (click)="downloadCurrent()" aria-label="Download current">
       <mat-icon>save_alt</mat-icon>
+    </button>
+
+    <button type="button" class="icon-btn subtle dock-permalink"
+      [disabled]="!call" (click)="copyPermalink()" aria-label="Copy permalink">
+      <mat-icon>link</mat-icon>
     </button>
 
     <div class="dock-autoplay" [class.on]="livefeedPlayback"

--- a/client/src/app/components/rdio-scanner/search/search.component.scss
+++ b/client/src/app/components/rdio-scanner/search/search.component.scss
@@ -117,6 +117,27 @@ $accent: rgb(0, 230, 118);
   z-index: 4;
 }
 
+.date-header {
+  align-items: baseline;
+  color: rgb(170, 170, 170);
+  display: flex;
+  gap: 12px;
+  letter-spacing: 1.5px;
+  margin: 14px 4px 6px;
+  text-transform: uppercase;
+}
+.date-header:first-child { margin-top: 4px; }
+.date-header .date-label {
+  color: $accent;
+  font-size: 11px;
+  font-weight: 600;
+  text-shadow: 0 0 4px rgba(0, 230, 118, 0.25);
+}
+.date-header .date-count {
+  color: rgb(120, 120, 120);
+  font-size: 10px;
+}
+
 /* Mobile breakpoint — sidebar collapses to slide-in */
 @media (max-width: 720px) {
   .search-layout {

--- a/client/src/app/components/rdio-scanner/search/search.component.ts
+++ b/client/src/app/components/rdio-scanner/search/search.component.ts
@@ -26,7 +26,9 @@ import {
     ViewChild,
 } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { BehaviorSubject } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { BehaviorSubject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import {
     RdioScannerCall,
     RdioScannerConfig,
@@ -41,6 +43,13 @@ import { RdioScannerService } from '../rdio-scanner.service';
 import { WaveformRibbon } from './waveform-ribbon';
 
 type PresetKey = 'hour' | 'today' | 'day' | 'week' | null;
+
+/** A single rendered row in the results scroll — either a call card or a
+ *  "Today · N", "Yesterday · N", "May 27 · N" group header. The header
+ *  rows are computed client-side from the call timestamps. */
+export type DisplayItem =
+    | { kind: 'header'; label: string; count: number; key: string }
+    | { kind: 'call'; call: RdioScannerCall | null; key: string };
 
 @Component({
     selector: 'rdio-scanner-search',
@@ -70,6 +79,10 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
     paused = false;
 
     results = new BehaviorSubject<Array<RdioScannerCall | null>>(new Array<RdioScannerCall | null>(20));
+    /** Flat list of rendered items: each entry is either a call row or a
+     *  date-header row marking a transition between adjacent calls on
+     *  different days. Recomputed in lock-step with `results.next()`. */
+    displayItems = new BehaviorSubject<DisplayItem[]>([]);
     resultsPending = false;
 
     time12h = false;
@@ -86,6 +99,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
     private config: RdioScannerConfig | undefined;
 
     private eventSubscription;
+    private querySubscription: Subscription | undefined;
 
     private limit = 200;
     private offset = 0;
@@ -108,9 +122,11 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         private rdioScannerService: RdioScannerService,
         private ngChangeDetectorRef: ChangeDetectorRef,
         private ngFormBuilder: FormBuilder,
+        private matSnackBar: MatSnackBar,
     ) {
         this.form = this.ngFormBuilder.group<{
-            date: string | null;
+            dateStart: string | null;
+            dateEnd: string | null;
             group: number;
             query: string;
             sort: number;
@@ -119,7 +135,8 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             talkgroup: number;
             unit: number | null;
         }>({
-            date: null,
+            dateStart: null,
+            dateEnd: null,
             group: -1,
             query: '',
             sort: -1,
@@ -131,6 +148,17 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
         this.eventSubscription = this.rdioScannerService.event
             .subscribe((event: RdioScannerEvent) => this.eventHandler(event));
+
+        // Debounce keystroke-driven query searches so typing doesn't
+        // spam the server one request per letter. 300 ms is long enough
+        // to consolidate fast typing without feeling sluggish.
+        const queryCtrl = this.form.get('query');
+        if (queryCtrl) {
+            this.querySubscription = queryCtrl.valueChanges.pipe(
+                debounceTime(300),
+                distinctUntilChanged(),
+            ).subscribe(() => this.formChangeHandler());
+        }
     }
 
     ngAfterViewInit(): void {
@@ -140,6 +168,7 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
     ngOnDestroy(): void {
         this.eventSubscription.unsubscribe();
+        this.querySubscription?.unsubscribe();
         this.ribbon?.destroy();
         this.ribbon = undefined;
         this.resultsResizeObserver?.disconnect();
@@ -189,6 +218,14 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         this.refreshResults();
     }
 
+    /** When the active filter pins to a single system, return its label
+     *  so the results header can show "594 results · Bradford County PA"
+     *  instead of just the count. Empty string otherwise. */
+    contextSystemLabel(): string {
+        const sys = this.getSelectedSystem();
+        return sys?.label || '';
+    }
+
     pageIndicator(): string {
         const total = this.playbackList?.count || 0;
         if (!total) return '— of —';
@@ -203,16 +240,37 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
     applyPreset(key: Exclude<PresetKey, null>): void {
         const now = new Date();
         let from: Date;
-        if (key === 'hour') from = new Date(now.getTime() - 60 * 60 * 1000);
-        else if (key === 'today') { from = new Date(now); from.setHours(0, 0, 0, 0); }
-        else if (key === 'day') from = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-        else from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        if (key === 'hour') {
+            from = new Date(now.getTime() - 60 * 60 * 1000);
+        } else if (key === 'today') {
+            from = new Date(now);
+            from.setHours(0, 0, 0, 0);
+        } else if (key === 'day') {
+            from = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        } else {
+            from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        }
         this.activePreset = key;
-        // Format as datetime-local string. Server widens any picked time to
-        // a 24h window today; once Phase 2 lands a real range, both ends
-        // of the preset will be honored.
-        const iso = new Date(from.getTime() - from.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
-        this.form.patchValue({ date: iso });
+        this.form.patchValue({
+            dateStart: this.toLocalISO(from),
+            dateEnd: this.toLocalISO(now),
+        });
+        this.formChangeHandler();
+    }
+
+    /** Convert a Date to the `YYYY-MM-DDTHH:mm` string a datetime-local
+     *  input expects, in local time. Manual rendering is needed because
+     *  Date.toISOString() emits UTC, which a local-time input would
+     *  re-interpret as local — shifting the value by the TZ offset. */
+    private toLocalISO(d: Date): string {
+        const pad = (n: number) => n.toString().padStart(2, '0');
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
+
+    /** Called whenever the user manually edits a date input. Clears the
+     *  active-preset chip so it doesn't mislead. */
+    onDateChange(): void {
+        this.activePreset = null;
         this.formChangeHandler();
     }
 
@@ -309,12 +367,58 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
                 calls.push(null);
             }
             this.results.next(calls);
+            this.displayItems.next(this.buildDisplayItems(calls));
         }
+    }
+
+    /** Walk the page's calls and emit a flat array with date-group
+     *  headers inserted at day boundaries. Skeleton (`null`) rows pass
+     *  through unchanged; they're grouped under the most recent header.
+     *  Header count is *only* the calls on this page in that group —
+     *  not the total in the archive — to avoid implying a global count
+     *  the user can't actually click to see. */
+    private buildDisplayItems(calls: Array<RdioScannerCall | null>): DisplayItem[] {
+        const out: DisplayItem[] = [];
+        let currentKey = '';
+        let currentHeader: Extract<DisplayItem, { kind: 'header' }> | null = null;
+
+        for (let i = 0; i < calls.length; i++) {
+            const c = calls[i];
+            const key = c ? this.dateKey(c.dateTime) : currentKey;
+            if (key !== currentKey) {
+                currentHeader = { kind: 'header', label: this.dateLabel(c?.dateTime), count: 0, key };
+                out.push(currentHeader);
+                currentKey = key;
+            }
+            if (currentHeader && c) currentHeader.count++;
+            out.push({ kind: 'call', call: c, key: `${key}-${i}` });
+        }
+        return out;
+    }
+
+    private dateKey(d: Date | string): string {
+        const dt = (d instanceof Date) ? d : new Date(d);
+        return `${dt.getFullYear()}-${dt.getMonth() + 1}-${dt.getDate()}`;
+    }
+
+    private dateLabel(d: Date | string | undefined): string {
+        if (!d) return '';
+        const dt = (d instanceof Date) ? d : new Date(d);
+        const now = new Date();
+        const yest = new Date(now); yest.setDate(yest.getDate() - 1);
+        if (this.dateKey(dt) === this.dateKey(now)) return 'Today';
+        if (this.dateKey(dt) === this.dateKey(yest)) return 'Yesterday';
+        const sameYear = dt.getFullYear() === now.getFullYear();
+        const opts: Intl.DateTimeFormatOptions = sameYear
+            ? { month: 'short', day: 'numeric' }
+            : { month: 'short', day: 'numeric', year: 'numeric' };
+        return dt.toLocaleDateString(undefined, opts);
     }
 
     resetForm(): void {
         this.form.reset({
-            date: null,
+            dateStart: null,
+            dateEnd: null,
             group: -1,
             query: '',
             sort: -1,
@@ -341,8 +445,13 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             sort: this.form.get('sort')?.value ?? -1,
         };
 
-        if (typeof this.form.value.date === 'string' && this.form.value.date) {
-            options.date = new Date(Date.parse(this.form.value.date));
+        const startVal = this.form.value.dateStart;
+        const endVal = this.form.value.dateEnd;
+        if (typeof startVal === 'string' && startVal) {
+            options.dateStart = new Date(Date.parse(startVal));
+        }
+        if (typeof endVal === 'string' && endVal) {
+            options.dateEnd = new Date(Date.parse(endVal));
         }
 
         if ((this.form.get('group')?.value ?? -1) >= 0) {
@@ -365,17 +474,26 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             if (talkgroup) options.talkgroup = talkgroup.id;
         }
 
-        // Unit + query are populated client-side for now; server-side
-        // support lands in Phase 2 (CallsSearchOptions doesn't yet expose
-        // a Unit field, and there's no free-text search at all).
+        // Unit filter is wired client-side but server CallsSearchOptions
+        // still lacks a Unit field — sent anyway so a future server
+        // version can honour it without a client change.
         const unitVal = this.form.get('unit')?.value;
         if (typeof unitVal === 'number' && unitVal > 0) {
             options.unit = unitVal;
         }
 
-        this.resultsPending = true;
-        this.form.disable({ emitEvent: false });
+        const queryVal = this.form.get('query')?.value;
+        if (typeof queryVal === 'string' && queryVal.trim()) {
+            options.query = queryVal.trim();
+        }
 
+        this.resultsPending = true;
+        // Form is intentionally kept enabled so the user can refine
+        // filters / keep typing while a previous request is in flight.
+        // The eventHandler discards stale responses by overwriting
+        // playbackList wholesale, so a slow earlier reply briefly
+        // overwriting a faster later one is a self-correcting cosmetic
+        // blip rather than a data integrity issue.
         this.rdioScannerService.searchCalls(options);
     }
 
@@ -433,6 +551,24 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
     downloadCurrent(): void {
         if (this.call) this.download(+this.call.id);
+    }
+
+    /** Copy a shareable URL pointing at the current call to the clipboard.
+     *  Format: <origin><pathname>?call=<id> — independent of whatever
+     *  query string is currently in the address bar, so navigating back
+     *  on the same machine reproduces the panel state. */
+    copyPermalink(): void {
+        if (!this.call) return;
+        const url = `${window.location.origin}${window.location.pathname}?call=${this.call.id}`;
+        const fallback = () => this.matSnackBar.open(url, 'OK', { duration: 6000 });
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).then(
+                () => this.matSnackBar.open('Permalink copied', '', { duration: 2000 }),
+                () => fallback(),
+            );
+        } else {
+            fallback();
+        }
     }
 
     // --- Time formatting (matches the main view drawer's m:ss.mmm / h:mm:ss.mmm) ---
@@ -506,7 +642,6 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
             this.playbackList = event.playbackList;
             this.refreshResults();
             this.resultsPending = false;
-            this.form.enable({ emitEvent: false });
 
             // Cards render this change-detection tick; re-measure on the
             // next microtask so autoFitPageSize sees the real card height

--- a/server/call.go
+++ b/server/call.go
@@ -616,6 +616,22 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 		}
 	}
 
+	// Free-text query — LIKE against talkgroup label/name + system label.
+	// SQL injection guard: we replace ' with '' inside the term, never
+	// inject raw user input. SQLite + Postgres both honour LIKE; we use
+	// lower() for case-insensitive matching across both dialects.
+	if q, ok := searchOptions.Query.(string); ok && q != "" {
+		safe := strings.ReplaceAll(q, "'", "''")
+		safe = strings.ReplaceAll(safe, "%", `\%`)
+		safe = strings.ReplaceAll(safe, "_", `\_`)
+		lower := strings.ToLower(safe)
+		pat := fmt.Sprintf("'%%%s%%'", lower)
+		where += fmt.Sprintf(
+			` AND (lower(t."label") LIKE %s OR lower(t."name") LIKE %s OR lower(s."label") LIKE %s)`,
+			pat, pat, pat,
+		)
+	}
+
 	// Aggregate MIN/MAX in one round-trip; with idx_calls_timestamp these
 	// resolve as index lookups rather than full sorts of the filtered set.
 	var minTs, maxTs sql.NullInt64
@@ -642,23 +658,46 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 		order = ascOrder
 	}
 
-	switch v := searchOptions.Date.(type) {
-	case time.Time:
-		var (
-			start time.Time
-			stop  time.Time
-		)
+	// Date filtering — prefer the explicit [DateStart, DateEnd] range
+	// when either is supplied. Falls back to the legacy single-Date
+	// 24 h window so older clients keep working.
+	var (
+		rangeStart, rangeEnd *time.Time
+	)
+	if t, ok := searchOptions.DateStart.(time.Time); ok {
+		rangeStart = &t
+	}
+	if t, ok := searchOptions.DateEnd.(time.Time); ok {
+		rangeEnd = &t
+	}
 
-		if order == ascOrder {
-			start = time.Date(v.Year(), v.Month(), v.Day(), v.Hour(), v.Minute(), 0, 0, time.UTC)
-			stop = start.Add(time.Hour*24 - time.Millisecond)
-
+	if rangeStart != nil || rangeEnd != nil {
+		if rangeStart != nil && rangeEnd != nil {
+			where += fmt.Sprintf(` AND (c."timestamp" BETWEEN %d AND %d)`, rangeStart.UnixMilli(), rangeEnd.UnixMilli())
+		} else if rangeStart != nil {
+			where += fmt.Sprintf(` AND c."timestamp" >= %d`, rangeStart.UnixMilli())
 		} else {
-			start = time.Date(v.Year(), v.Month(), v.Day(), v.Hour(), v.Minute(), 0, 0, time.UTC).Add(time.Hour*-24 + time.Millisecond)
-			stop = time.Date(v.Year(), v.Month(), v.Day(), v.Hour(), v.Minute(), 0, 0, time.UTC)
+			where += fmt.Sprintf(` AND c."timestamp" <= %d`, rangeEnd.UnixMilli())
 		}
+	} else {
+		switch v := searchOptions.Date.(type) {
+		case time.Time:
+			var (
+				start time.Time
+				stop  time.Time
+			)
 
-		where += fmt.Sprintf(` AND (c."timestamp" BETWEEN %d AND %d)`, start.UnixMilli(), stop.UnixMilli())
+			if order == ascOrder {
+				start = time.Date(v.Year(), v.Month(), v.Day(), v.Hour(), v.Minute(), 0, 0, time.UTC)
+				stop = start.Add(time.Hour*24 - time.Millisecond)
+
+			} else {
+				start = time.Date(v.Year(), v.Month(), v.Day(), v.Hour(), v.Minute(), 0, 0, time.UTC).Add(time.Hour*-24 + time.Millisecond)
+				stop = time.Date(v.Year(), v.Month(), v.Day(), v.Hour(), v.Minute(), 0, 0, time.UTC)
+			}
+
+			where += fmt.Sprintf(` AND (c."timestamp" BETWEEN %d AND %d)`, start.UnixMilli(), stop.UnixMilli())
+		}
 	}
 
 	switch v := searchOptions.Limit.(type) {
@@ -811,10 +850,16 @@ func (calls *Calls) WriteCall(call *Call, db *Database) (uint64, error) {
 }
 
 type CallsSearchOptions struct {
+	// Date is the legacy single-date filter — server widens it to a
+	// 24 h window (direction depends on Sort). Kept for backward
+	// compatibility with older clients. Prefer DateStart/DateEnd.
 	Date      any `json:"date,omitempty"`
+	DateStart any `json:"dateStart,omitempty"`
+	DateEnd   any `json:"dateEnd,omitempty"`
 	Group     any `json:"group,omitempty"`
 	Limit     any `json:"limit,omitempty"`
 	Offset    any `json:"offset,omitempty"`
+	Query     any `json:"query,omitempty"`
 	Sort      any `json:"sort,omitempty"`
 	System    any `json:"system,omitempty"`
 	Tag       any `json:"tag,omitempty"`
@@ -833,6 +878,20 @@ func (searchOptions *CallsSearchOptions) fromMap(m map[string]any) *CallsSearchO
 		}
 	}
 
+	switch v := m["dateStart"].(type) {
+	case string:
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			searchOptions.DateStart = t
+		}
+	}
+
+	switch v := m["dateEnd"].(type) {
+	case string:
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			searchOptions.DateEnd = t
+		}
+	}
+
 	switch v := m["group"].(type) {
 	case string:
 		searchOptions.Group = v
@@ -846,6 +905,14 @@ func (searchOptions *CallsSearchOptions) fromMap(m map[string]any) *CallsSearchO
 	switch v := m["offset"].(type) {
 	case float64:
 		searchOptions.Offset = uint(v)
+	}
+
+	switch v := m["query"].(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed != "" {
+			searchOptions.Query = trimmed
+		}
 	}
 
 	switch v := m["sort"].(type) {


### PR DESCRIPTION
…aveform

server/call.go:
  + DateStart/DateEnd added to CallsSearchOptions alongside legacy Date. Search() prefers the explicit range; falls back to the legacy 24h- around-Date for older clients.
  + Query free-text wired to LIKE against talkgroup.label, talkgroup.name and system.label (escapes ' / % / _; lower() for portable case- insensitive matching across SQLite and Postgres).

search panel:
  + From/To datetime-local replaces the single Date input.
  + All four quick presets (Last hr / Today / 24h / Week) now actually work. The previous version sent only one end of the server's 24h window so sort direction broke them all in different ways (Today showed yesterday, Week landed 8 days ago, etc).
  + Manual date edits clear the active preset chip.
  + Free-text search wired with 300 ms debounce + distinctUntilChanged. Form stays enabled while a request is in flight so the user can keep typing while a previous reply resolves.
  + Permalink button copies <origin><pathname>?call=<id> to clipboard via the snackbar pattern used elsewhere in the project.
  + Date section headers ("Today", "Yesterday", "May 27", "May 27, 2025" when crossing year) interleaved between cards at day boundaries; per-page counts only so we don't imply global totals the user can't navigate to.
  + System name appears next to result count when filtered to one system.
  + First/last pagination buttons + clearer "X-Y of Z . pg N/M" indicator. Edges hide on mobile to keep the bar compact.

rdio-scanner component (deep-link consumer):
  + Parse ?call=<id> in constructor; hold in pendingDeepLinkCallId.
  + Consume on the first post-auth Config event. Access-code-restricted instances are naturally gated because the server only sends Config after PIN validation (controller.go:359 enforces this), so no separate authorization check is needed in the deep-link path.
  + Strip ?call= from the URL after consumption so refresh and back/ forward don't repeat playback.

waveform resolution:
  + service.computePeaks default raised 64 -> 1024 buckets so the search dock's canvas ribbon has enough source detail to render close to one peak per output pixel on typical desktop widths.
  + Main view drawer downsamples back to 64 via max-pool before render so its SVG bar layout (viewBox 0 0 64 30) stays unchanged.

Phase 2 still deferred: per-row duration and per-row mini waveforms (both need server schema or on-the-fly file inspection) and the Unit filter's server side.