### PR TITLE
archive: per-row duration + mini waveform, paginator polish, pause/pl…

### DIFF
--- a/client/src/app/components/rdio-scanner/rdio-scanner.service.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.service.ts
@@ -444,6 +444,16 @@ export class RdioScannerService implements OnDestroy {
             this.skipDelay = undefined;
         }
 
+        // Clicking play on a specific call is an explicit user intent
+        // that should override any earlier pause. Without this, both
+        // queue() and play() would short-circuit on livefeedPaused and
+        // the newly-fetched call would silently sit in the queue.
+        if (this.livefeedPaused) {
+            this.livefeedPaused = false;
+            this.audioContext?.resume();
+            this.event.emit({ pause: false });
+        }
+
         this.playbackPending = id;
 
         this.stop();
@@ -658,6 +668,24 @@ export class RdioScannerService implements OnDestroy {
             out[i] = peak > 1 ? 1 : peak;
         }
         return out;
+    }
+
+    /** Decode the per-row mini-waveform peaks the server ships in search
+     *  results. Wire format: base64-encoded raw byte array (Go's default
+     *  JSON encoding for []byte) where each byte is 0–255 = 0..1
+     *  amplitude. Returns an empty array on any decode error so the UI
+     *  hides the thumbnail rather than choking. */
+    private decodePeaksBase64(b64: string): number[] {
+        try {
+            const bin = atob(b64);
+            const out = new Array<number>(bin.length);
+            for (let i = 0; i < bin.length; i++) {
+                out[i] = bin.charCodeAt(i) / 255;
+            }
+            return out;
+        } catch {
+            return [];
+        }
     }
 
     // onSourceEnded is the natural-end callback for the playing source.
@@ -1225,7 +1253,17 @@ export class RdioScannerService implements OnDestroy {
                     this.playbackList = message[1];
 
                     if (this.playbackList) {
-                        this.playbackList.results = this.playbackList.results.map((call) => this.transformCall(call));
+                        this.playbackList.results = this.playbackList.results.map((call) => {
+                            // Server ships `peaks` as a JSON base64 string
+                            // (Go marshals []byte that way). Decode to a
+                            // normalised float array so the search component
+                            // can pass it straight to WaveformRibbon.
+                            const raw = (call as unknown as { peaks?: unknown }).peaks;
+                            if (typeof raw === 'string' && raw.length > 0) {
+                                call.peaks = this.decodePeaksBase64(raw);
+                            }
+                            return this.transformCall(call);
+                        });
 
                         this.event.emit({ playbackList: this.playbackList });
 

--- a/client/src/app/components/rdio-scanner/rdio-scanner.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.ts
@@ -47,11 +47,19 @@ export interface RdioScannerCall {
     audioType?: string;
     dateTime: Date;
     delayed: boolean;
+    /** Total clip length in milliseconds. 0 when unknown (pre-migration
+     *  row that was never re-processed). The archive UI degrades to a
+     *  dash placeholder in that case. */
+    duration?: number;
     frequencies?: RdioScannerCallFrequency[];
     frequency?: number;
     groupsData?: RdioScannerGroupData[];
     id: number;
     patches: number[];
+    /** Decoded mini-waveform peaks (0..1 amplitude per bucket, ~32
+     *  buckets). Set from the server-supplied base64 byte array in the
+     *  ListCall response by RdioScannerService. */
+    peaks?: number[];
     source?: number;
     sources?: RdioScannerCallSource[];
     system: number;

--- a/client/src/app/components/rdio-scanner/search/search-cards-dock.scss
+++ b/client/src/app/components/rdio-scanner/search/search-cards-dock.scss
@@ -31,20 +31,6 @@ $accent: rgb(0, 230, 118);
 .results-loading { color: $accent; font-size: 11px; letter-spacing: 0.5px; text-transform: uppercase; }
 .results-spacer { flex: 1; }
 .sidebar-toggle { display: none; }
-.paginator-mini {
-  align-items: center;
-  display: flex;
-  font-size: 11px;
-  gap: 4px;
-}
-.page-indicator {
-  color: rgb(180, 180, 180);
-  font-family: 'Courier New', monospace;
-  font-size: 11px;
-  min-width: 160px;
-  text-align: center;
-  white-space: nowrap;
-}
 
 .results-scroll {
   flex: 1;
@@ -67,7 +53,7 @@ $accent: rgb(0, 230, 118);
   cursor: pointer;
   display: grid;
   gap: 10px;
-  grid-template-columns: 38px 1fr auto;
+  grid-template-columns: 38px 1fr 140px 48px auto;
   margin-bottom: 8px;
   padding: 10px 12px;
   transition: border-color 100ms;
@@ -81,6 +67,18 @@ $accent: rgb(0, 230, 118);
     cursor: default;
     height: 60px;
   }
+}
+.result-card .wave-mini { height: 24px; min-width: 0; }
+.result-card .wave-mini canvas { display: block; height: 24px; width: 100%; }
+.result-card .dur {
+  color: rgb(170, 170, 170);
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  text-align: right;
+}
+@media (max-width: 640px) {
+  .result-card { grid-template-columns: 38px 1fr 60px auto; }
+  .result-card .wave-mini { display: none; }
 }
 .result-card .meta { min-width: 0; }
 .result-card .row1 {
@@ -210,8 +208,8 @@ $accent: rgb(0, 230, 118);
   .search-main { grid-column: 1; grid-row: 1 / 2; }
   .search-dock { grid-column: 1; grid-row: 2; }
   .sidebar-toggle { display: inline-flex; }
-  .paginator-mini .edge { display: none; }
-  .page-indicator { min-width: auto; }
+  .results-paginator .edge { display: none; }
+  .pg-readout { min-width: auto; }
   .search-dock {
     gap: 8px;
     grid-template-columns: 40px 1fr auto;

--- a/client/src/app/components/rdio-scanner/search/search.component.html
+++ b/client/src/app/components/rdio-scanner/search/search.component.html
@@ -119,25 +119,6 @@
         <span class="results-loading">Searching…</span>
       }
       <span class="results-spacer"></span>
-      <div class="paginator-mini">
-        <button type="button" class="icon-btn subtle edge"
-          [disabled]="!canPrevPage()" (click)="firstPage()" aria-label="First page">
-          <mat-icon>first_page</mat-icon>
-        </button>
-        <button type="button" class="icon-btn subtle"
-          [disabled]="!canPrevPage()" (click)="prevPage()" aria-label="Previous page">
-          <mat-icon>chevron_left</mat-icon>
-        </button>
-        <span class="page-indicator">{{ pageIndicator() }}</span>
-        <button type="button" class="icon-btn subtle"
-          [disabled]="!canNextPage()" (click)="nextPage()" aria-label="Next page">
-          <mat-icon>chevron_right</mat-icon>
-        </button>
-        <button type="button" class="icon-btn subtle edge"
-          [disabled]="!canNextPage()" (click)="lastPage()" aria-label="Last page">
-          <mat-icon>last_page</mat-icon>
-        </button>
-      </div>
     </div>
 
     <div class="results-scroll" #scrollableResults>
@@ -146,7 +127,6 @@
           @if (item.kind === 'header') {
             <div class="date-header">
               <span class="date-label">{{ item.label }}</span>
-              <span class="date-count">{{ item.count }} on page</span>
             </div>
           } @else if (item.call) {
             <div class="result-card"
@@ -184,6 +164,14 @@
                   }
                 </div>
               </div>
+              <div class="wave-mini">
+                @if (item.call.peaks?.length && item.call.duration) {
+                  <canvas #rowCanvas
+                    [attr.data-call-id]="item.call.id"
+                    aria-label="Waveform thumbnail"></canvas>
+                }
+              </div>
+              <span class="dur">{{ formatDurShort(item.call.duration) }}</span>
               <button type="button" class="icon-btn subtle dl"
                 (click)="$event.stopPropagation(); download(+item.call.id)"
                 aria-label="Download">
@@ -198,6 +186,26 @@
           <div class="empty-state">No calls match the current filters.</div>
         }
       }
+    </div>
+
+    <div class="results-paginator" role="navigation" aria-label="Result pages">
+      <button type="button" class="pg-btn edge"
+        [disabled]="!canPrevPage()" (click)="firstPage()" aria-label="First page">
+        <mat-icon>first_page</mat-icon>
+      </button>
+      <button type="button" class="pg-btn"
+        [disabled]="!canPrevPage()" (click)="prevPage()" aria-label="Previous page">
+        <mat-icon>chevron_left</mat-icon>
+      </button>
+      <span class="pg-readout">{{ pageIndicator() }}</span>
+      <button type="button" class="pg-btn"
+        [disabled]="!canNextPage()" (click)="nextPage()" aria-label="Next page">
+        <mat-icon>chevron_right</mat-icon>
+      </button>
+      <button type="button" class="pg-btn edge"
+        [disabled]="!canNextPage()" (click)="lastPage()" aria-label="Last page">
+        <mat-icon>last_page</mat-icon>
+      </button>
     </div>
   </main>
 

--- a/client/src/app/components/rdio-scanner/search/search.component.scss
+++ b/client/src/app/components/rdio-scanner/search/search.component.scss
@@ -134,10 +134,6 @@ $accent: rgb(0, 230, 118);
   font-size: 11px;
   font-weight: 500;
 }
-.date-header .date-count {
-  color: rgb(120, 120, 120);
-  font-size: 10px;
-}
 
 /* Chunky bevelled play/pause used in cards + dock + result rows. */
 .btn-play {
@@ -176,6 +172,49 @@ $accent: rgb(0, 230, 118);
 
 .spin { animation: spin 1s linear infinite; }
 @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+
+/* Paginator strip — below results-scroll, above the dock. Chassis tone
+ * with a top bevel so it reads as a distinct hardware-style band. */
+$pg-chassis-dark: rgb(28, 28, 28);
+$pg-lcd-bg: rgb(209, 238, 238);
+$pg-lcd-text: rgba(0, 0, 0, 0.8);
+.results-paginator {
+  align-items: center;
+  background: $pg-chassis-dark;
+  border-top: 1px solid $bevel-light;
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-shrink: 0;
+  gap: 6px;
+  justify-content: center;
+  padding: 8px 16px;
+}
+.pg-btn {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: rgb(220, 220, 220);
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  padding: 6px 10px;
+  &:hover { color: $accent; }
+  &:disabled { color: rgb(80, 80, 80); cursor: not-allowed; }
+  mat-icon { font-size: 24px; height: 24px; line-height: 24px; width: 24px; }
+}
+.pg-readout {
+  background: $pg-lcd-bg;
+  box-shadow: 2px 2px 4px rgb(0, 0, 0) inset, 1px 1px 2px 1px rgb(255, 255, 255);
+  color: $pg-lcd-text;
+  font-family: 'Courier New', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  margin: 0 4px;
+  min-width: 200px;
+  padding: 4px 10px;
+  text-align: center;
+  white-space: nowrap;
+}
 
 /* Mobile breakpoint — sidebar collapses to slide-in */
 @media (max-width: 720px) {

--- a/client/src/app/components/rdio-scanner/search/search.component.ts
+++ b/client/src/app/components/rdio-scanner/search/search.component.ts
@@ -23,7 +23,9 @@ import {
     Component,
     ElementRef,
     OnDestroy,
+    QueryList,
     ViewChild,
+    ViewChildren,
 } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -108,8 +110,10 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
 
     @ViewChild('dockCanvas', { static: false }) private dockCanvasRef: ElementRef<HTMLCanvasElement> | undefined;
     @ViewChild('scrollableResults', { static: false }) private scrollableResultsRef: ElementRef<HTMLDivElement> | undefined;
+    @ViewChildren('rowCanvas') private rowCanvases: QueryList<ElementRef<HTMLCanvasElement>> | undefined;
 
     private ribbon: WaveformRibbon | undefined;
+    private rowRibbons = new Map<number, WaveformRibbon>();
     private resultsResizeObserver: ResizeObserver | undefined;
 
     // Padding inside .results-scroll (must stay in sync with SCSS).
@@ -164,6 +168,14 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
     ngAfterViewInit(): void {
         this.mountRibbon();
         this.observeResultsResize();
+
+        // Each card has a `#rowCanvas` template ref. Whenever the QueryList
+        // emits (results re-render after pagination, filter change, or
+        // initial load) sync the per-row WaveformRibbon instances.
+        this.rowCanvases?.changes.subscribe(() => this.syncRowRibbons());
+        // First sync covers the case where cards are already in the DOM
+        // by the time AfterViewInit fires.
+        this.syncRowRibbons();
     }
 
     ngOnDestroy(): void {
@@ -171,6 +183,8 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         this.querySubscription?.unsubscribe();
         this.ribbon?.destroy();
         this.ribbon = undefined;
+        this.rowRibbons.forEach((r) => r.destroy());
+        this.rowRibbons.clear();
         this.resultsResizeObserver?.disconnect();
         this.resultsResizeObserver = undefined;
     }
@@ -708,6 +722,62 @@ export class RdioScannerSearchComponent implements AfterViewInit, OnDestroy {
         this.pageIndex = Math.floor(firstVisibleRow / newPageSize);
         this.refreshResults();
         this.ngChangeDetectorRef.detectChanges();
+    }
+
+    /** Render m:ss for a per-card duration. Returns a dash placeholder
+     *  when duration is unknown (pre-migration row), matching the
+     *  graceful-degradation contract documented in the type. */
+    formatDurShort(ms: number | undefined): string {
+        if (!ms || ms <= 0) return '—:——';
+        const totalSec = Math.floor(ms / 1000);
+        const m = Math.floor(totalSec / 60);
+        const s = (totalSec % 60).toString().padStart(2, '0');
+        return `${m}:${s}`;
+    }
+
+    /** Mount/update/destroy the per-row mini waveform ribbons in sync
+     *  with the current page's <canvas #rowCanvas> elements. Called from
+     *  ngAfterViewInit and on every QueryList changes emission. */
+    private syncRowRibbons(): void {
+        if (!this.rowCanvases) return;
+
+        const seen = new Set<number>();
+        this.rowCanvases.forEach((ref) => {
+            const canvas = ref.nativeElement;
+            const idStr = canvas.dataset['callId'];
+            if (!idStr) return;
+            const id = parseInt(idStr, 10);
+            seen.add(id);
+
+            const row = this.playbackList?.results.find((c) => c?.id === id);
+            if (!row || !row.peaks?.length || !row.duration) return;
+
+            const existing = this.rowRibbons.get(id);
+            const durationSec = row.duration / 1000;
+            if (existing) {
+                existing.set({ peaks: row.peaks, duration: durationSec });
+            } else {
+                this.rowRibbons.set(id, new WaveformRibbon(canvas, {
+                    peaks: row.peaks,
+                    duration: durationSec,
+                    currentTime: 0,
+                    bgColor: 'rgba(0, 230, 118, 0.4)',
+                    fgColor: 'rgb(0, 230, 118)',
+                    cursorColor: 'rgb(220, 255, 235)',
+                    cursorWidth: 1.5,
+                    showCursor: false,
+                }));
+            }
+        });
+
+        // Destroy ribbons whose canvas is no longer in the DOM (page
+        // navigation moved off the row).
+        for (const [id, ribbon] of this.rowRibbons) {
+            if (!seen.has(id)) {
+                ribbon.destroy();
+                this.rowRibbons.delete(id);
+            }
+        }
     }
 
     private mountRibbon(): void {

--- a/server/audio_metrics.go
+++ b/server/audio_metrics.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2019-2026 Chrystian Huot <chrystian.huot@saubeo.solutions>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+	"os/exec"
+)
+
+// PeaksBucketCount is the fixed length of the per-call peak envelope we
+// store and ship to the archive UI. 32 reads as smooth enough on a
+// ~150-px-wide row thumbnail without bloating the DB or the search
+// response payload (32 bytes per call).
+const PeaksBucketCount = 32
+
+// computeAudioMetrics decodes the supplied M4A bytes to mono PCM at
+// 8 kHz via an `ffmpeg -f f32le` subprocess and returns the clip's
+// duration (ms) plus a fixed-length peak envelope (32 bytes, each in
+// [0, 255] where 255 = full-scale).
+//
+// The choice of 8 kHz mono matches typical radio audio bandwidth; we
+// don't need higher fidelity for envelope detection, and the smaller
+// sample count keeps the in-Go bucketing loop trivially fast.
+//
+// Returns zeroed values + a wrapped error if ffmpeg is unavailable or
+// the decode fails — the caller logs and stores zeros, which the UI
+// renders as "no duration / no waveform" without breaking layout.
+func computeAudioMetrics(audio []byte) (durationMs uint, peaks []byte, err error) {
+	if len(audio) == 0 {
+		return 0, nil, errors.New("empty audio")
+	}
+
+	cmd := exec.Command(
+		"ffmpeg",
+		"-loglevel", "error",
+		"-i", "-",
+		"-ac", "1", // force mono — symmetric peaks
+		"-ar", "8000", // 8 kHz — enough for voice envelope
+		"-f", "f32le", // 32-bit little-endian floats
+		"-",
+	)
+	cmd.Stdin = bytes.NewReader(audio)
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if runErr := cmd.Run(); runErr != nil {
+		return 0, nil, errors.New("ffmpeg decode failed: " + runErr.Error() + ": " + stderr.String())
+	}
+
+	pcm := stdout.Bytes()
+	numSamples := len(pcm) / 4 // float32 = 4 bytes
+	if numSamples == 0 {
+		return 0, nil, errors.New("ffmpeg produced no PCM samples")
+	}
+
+	durationMs = uint(float64(numSamples) / 8000.0 * 1000.0)
+
+	peaks = make([]byte, PeaksBucketCount)
+	bucketSamples := numSamples / PeaksBucketCount
+	if bucketSamples == 0 {
+		bucketSamples = 1
+	}
+
+	for i := 0; i < PeaksBucketCount; i++ {
+		from := i * bucketSamples * 4
+		to := from + bucketSamples*4
+		// Last bucket sweeps the tail so we don't drop a few samples
+		// to integer-division rounding.
+		if i == PeaksBucketCount-1 || to > len(pcm) {
+			to = len(pcm)
+		}
+		var maxAbs float32
+		for j := from; j+4 <= to; j += 4 {
+			bits := binary.LittleEndian.Uint32(pcm[j : j+4])
+			v := math.Float32frombits(bits)
+			if v < 0 {
+				v = -v
+			}
+			if v > maxAbs {
+				maxAbs = v
+			}
+		}
+		if maxAbs > 1 {
+			maxAbs = 1
+		}
+		peaks[i] = byte(maxAbs * 255)
+	}
+
+	return durationMs, peaks, nil
+}

--- a/server/call.go
+++ b/server/call.go
@@ -74,6 +74,8 @@ type Call struct {
 	AudioMime     string
 	AudioPath     string
 	Delayed       bool
+	Duration      uint  // milliseconds; 0 if unknown (pre-migration row)
+	Peaks         []byte // 32 bucketed peak amplitudes (0–255); nil if unknown
 	Frequencies   []CallFrequency
 	Meta          CallMeta
 	Patches       []uint
@@ -717,18 +719,28 @@ func (calls *Calls) Search(searchOptions *CallsSearchOptions, client *Client) (*
 		return nil, formatError(err, query)
 	}
 
-	query = fmt.Sprintf(`SELECT c."callId", c."timestamp", s."systemRef", t."talkgroupRef" FROM "calls" AS c LEFT JOIN "systems" AS s ON s."systemId" = c."systemId" LEFT JOIN "talkgroups" AS t ON t."talkgroupId" = c."talkgroupId" LEFT JOIN "delayed" AS d ON d."callId" = c."callId" WHERE %s ORDER BY c."timestamp" %s LIMIT %d OFFSET %d`, where, order, limit, offset)
+	query = fmt.Sprintf(`SELECT c."callId", c."timestamp", c."duration", c."peaks", s."systemRef", t."talkgroupRef" FROM "calls" AS c LEFT JOIN "systems" AS s ON s."systemId" = c."systemId" LEFT JOIN "talkgroups" AS t ON t."talkgroupId" = c."talkgroupId" LEFT JOIN "delayed" AS d ON d."callId" = c."callId" WHERE %s ORDER BY c."timestamp" %s LIMIT %d OFFSET %d`, where, order, limit, offset)
 	if rows, err = db.Sql.Query(query); err != nil && err != sql.ErrNoRows {
 		return nil, formatError(err, query)
 	}
 
 	for rows.Next() {
 		searchResult := CallsSearchResult{}
-		if err = rows.Scan(&searchResult.Id, &timestamp, &searchResult.System, &searchResult.Talkgroup); err != nil {
+		var (
+			durationRow sql.NullInt64
+			peaksRow    []byte
+		)
+		if err = rows.Scan(&searchResult.Id, &timestamp, &durationRow, &peaksRow, &searchResult.System, &searchResult.Talkgroup); err != nil {
 			break
 		}
 
 		searchResult.Timestamp = time.UnixMilli(timestamp)
+		if durationRow.Valid {
+			searchResult.Duration = uint(durationRow.Int64)
+		}
+		if len(peaksRow) > 0 {
+			searchResult.Peaks = peaksRow
+		}
 
 		searchResults.Results = append(searchResults.Results, searchResult)
 	}
@@ -786,15 +798,23 @@ func (calls *Calls) WriteCall(call *Call, db *Database) (uint64, error) {
 	// AudioFilename/AudioMime arrive from untrusted multipart uploads
 	// (parsers.go), and previously landed in the query via '%s' with no
 	// escaping at all — a pre-auth SQLi vector.
-	if db.Config.DbType == DbTypePostgresql {
-		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "audioPath", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES ($1, $2, $3, $4, %d, %d, %d, %d) RETURNING "callId"`, call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
+	// Peaks may legitimately be nil if computeAudioMetrics failed; NULL
+	// is the right wire value for the column. The driver maps nil []byte
+	// to NULL on all three supported DBs.
+	var peaksParam any = call.Peaks
+	if len(call.Peaks) == 0 {
+		peaksParam = nil
+	}
 
-		err = tx.QueryRow(query, emptyAudio, call.AudioFilename, call.AudioMime, call.AudioPath).Scan(&call.Id)
+	if db.Config.DbType == DbTypePostgresql {
+		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "audioPath", "duration", "peaks", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES ($1, $2, $3, $4, %d, $5, %d, %d, %d, %d) RETURNING "callId"`, call.Duration, call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
+
+		err = tx.QueryRow(query, emptyAudio, call.AudioFilename, call.AudioMime, call.AudioPath, peaksParam).Scan(&call.Id)
 
 	} else {
-		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "audioPath", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES (?, ?, ?, ?, %d, %d, %d, %d)`, call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
+		query = fmt.Sprintf(`INSERT INTO "calls" ("audio", "audioFilename", "audioMime", "audioPath", "duration", "peaks", "siteRef", "systemId", "talkgroupId", "timestamp") VALUES (?, ?, ?, ?, %d, ?, %d, %d, %d, %d)`, call.Duration, call.SiteRef, call.System.Id, call.Talkgroup.Id, call.Timestamp.UnixMilli())
 
-		if res, err = tx.Exec(query, emptyAudio, call.AudioFilename, call.AudioMime, call.AudioPath); err == nil {
+		if res, err = tx.Exec(query, emptyAudio, call.AudioFilename, call.AudioMime, call.AudioPath, peaksParam); err == nil {
 			if id, err := res.LastInsertId(); err == nil {
 				call.Id = uint64(id)
 			}
@@ -943,6 +963,13 @@ type CallsSearchResult struct {
 	System    uint      `json:"system"`
 	Talkgroup uint      `json:"talkgroup"`
 	Timestamp time.Time `json:"dateTime"`
+	// Duration in milliseconds. 0 if the row predates the duration column
+	// migration; clients should fall back to "—:—" in that case.
+	Duration uint `json:"duration,omitempty"`
+	// Peaks are 32 amplitude bytes (0–255 = 0–full-scale). Empty slice
+	// when unknown (pre-migration row); clients then hide the mini
+	// waveform thumbnail rather than render a flat bar.
+	Peaks []byte `json:"peaks,omitempty"`
 }
 
 type CallsSearchResults struct {

--- a/server/controller.go
+++ b/server/controller.go
@@ -336,6 +336,17 @@ func (controller *Controller) IngestCall(call *Call) {
 		controller.Logs.LogEvent(LogLevelWarn, err.Error())
 	}
 
+	// Pre-compute duration + peak envelope from the (now-M4A) audio so
+	// the archive UI can render per-row duration and a mini waveform
+	// without any decode on the search path. Non-fatal: a failure here
+	// leaves both zeroed and the UI degrades gracefully.
+	if duration, peaks, mErr := computeAudioMetrics(call.Audio); mErr == nil {
+		call.Duration = duration
+		call.Peaks = peaks
+	} else {
+		controller.Logs.LogEvent(LogLevelWarn, "audio metrics: "+mErr.Error())
+	}
+
 	if id, err := controller.Calls.WriteCall(call, controller.Database); err == nil {
 		call.Id = id
 

--- a/server/database.go
+++ b/server/database.go
@@ -163,6 +163,10 @@ func (db *Database) migrate() error {
 		return formatError(err, "")
 	}
 
+	if err := migrateCallsDurationPeaks(db); err != nil {
+		return formatError(err, "")
+	}
+
 	if err := migrateApikeys(db); err != nil {
 		return formatError(err, "")
 	}

--- a/server/migrations.go
+++ b/server/migrations.go
@@ -51,6 +51,39 @@ func migrateCallsAudioPath(db *Database) error {
 	return nil
 }
 
+// migrateCallsDurationPeaks adds the per-call duration (ms) and peak-
+// envelope columns used by the archive UI's card rows and mini waveform.
+// Old rows get duration=0 and peaks=NULL; the UI degrades gracefully
+// (shows a dash for duration, hides the waveform) until a future backfill
+// task fills them in.
+func migrateCallsDurationPeaks(db *Database) error {
+	formatError := errorFormatter("migration", "migrateCallsDurationPeaks")
+
+	if _, err := db.Sql.Exec(`SELECT "duration" FROM "calls" LIMIT 1`); err == nil {
+		return nil
+	}
+
+	log.Println("adding calls.duration and calls.peaks columns...")
+
+	// duration: integer ms; peaks: per-DB blob type
+	blobType := "blob"
+	if db.Config.DbType == DbTypePostgresql {
+		blobType = "bytea"
+	}
+
+	stmts := []string{
+		`ALTER TABLE "calls" ADD COLUMN "duration" integer NOT NULL DEFAULT 0`,
+		fmt.Sprintf(`ALTER TABLE "calls" ADD COLUMN "peaks" %s`, blobType),
+	}
+	for _, q := range stmts {
+		if _, err := db.Sql.Exec(q); err != nil {
+			return formatError(err, q)
+		}
+	}
+
+	return nil
+}
+
 func migrateAccesses(db *Database) error {
 	var (
 		err   error

--- a/server/mysql.go
+++ b/server/mysql.go
@@ -118,6 +118,8 @@ var MysqlSchema = []string{
     "audioFilename" text NOT NULL,
     "audioMime" text NOT NULL,
     "audioPath" text NOT NULL,
+    "duration" integer NOT NULL DEFAULT 0,
+    "peaks" blob,
     "siteRef" integer NOT NULL DEFAULT 0,
     "systemId" bigint NOT NULL,
     "talkgroupId" bigint NOT NULL,

--- a/server/postgresql.go
+++ b/server/postgresql.go
@@ -118,6 +118,8 @@ var PostgresqlSchema = []string{
     "audioFilename" text NOT NULL,
     "audioMime" text NOT NULL,
     "audioPath" text NOT NULL DEFAULT '',
+    "duration" integer NOT NULL DEFAULT 0,
+    "peaks" bytea,
     "siteRef" integer NOT NULL DEFAULT 0,
     "systemId" bigint NOT NULL,
     "talkgroupId" bigint NOT NULL,

--- a/server/sqlite.go
+++ b/server/sqlite.go
@@ -118,6 +118,8 @@ var SqliteSchema = []string{
     "audioFilename" text NOT NULL,
     "audioMime" text NOT NULL,
     "audioPath" text NOT NULL DEFAULT '',
+    "duration" integer NOT NULL DEFAULT 0,
+    "peaks" blob,
     "siteRef" integer NOT NULL DEFAULT 0,
     "systemId" integer NOT NULL,
     "talkgroupId" integer NOT NULL,


### PR DESCRIPTION
…ay fix

server:
  + duration (ms) and peaks (32 bytes, max-abs per bucket) columns added to "calls" in sqlite / mysql / postgresql schemas. New migration migrateCallsDurationPeaks ALTERs older DBs with both columns (peaks nullable; defaults handled per dialect).
  + audio_metrics.go: computeAudioMetrics decodes the converted M4A via an ffmpeg subprocess (mono, 8 kHz, f32le) and returns duration in ms + a 32-byte peak envelope (max-abs per bucket scaled 0..255).
  + ProcessUploadedCall runs computeAudioMetrics after ffmpeg.Convert; failure is non-fatal (logged, zeros stored, UI degrades).
  + WriteCall INSERT writes the new columns. CallsSearchResult ships Duration uint + Peaks []byte (Go marshals as base64 in JSON).
  + Search SELECT pulls both, NULL-safe via sql.NullInt64 / empty slice.

client:
  + RdioScannerCall gains duration?: number (ms) + peaks?: number[] (decoded floats 0..1).
  + Service ListCall handler decodes the base64 peaks string via atob() into number[] so the search component receives a ready-to-render array.
  + Search cards now show m:ss duration + a per-row canvas waveform thumbnail. Ribbons mounted/destroyed via @ViewChildren reconciliation so navigating pages doesn't leak ResizeObservers.
  + Card grid is now 38px play | 1fr meta | 140px wave | 48px dur | hover-revealed download. Below 640px the waveform hides; duration stays.

paginator + visual polish:
  + Moved out of the top results-header strip into a dedicated footer band below results-scroll. Chassis-dark background with a top bevel + drop shadow so it reads as a hardware-style control strip.
  + Buttons are no longer .subtle: rgb(220, 220, 220) base, accent green on hover, dim disabled state. Icons 24px (was 20px), wider padding for fingertip-friendly hit area.
  + Page indicator is now an LCD chip (recessed inset shadow + cyan- green background + dark monospaced text) matching the dock timecode chip.
  + Date headers no longer show "N on page" — just the day label ("Today", "Yesterday", "May 27").

bug fix:
  + loadAndPlay now clears livefeedPaused and resumes the audio context before fetching the requested call. Previously: pause one clip, click play on a different row -> new clip silently queued because both queue() and play() short-circuit on livefeedPaused. Explicit "play this clip" intent now overrules earlier pause across all entry points (search cards, dock, deep-link consumer).

Backfill of duration / peaks for pre-migration rows is deferred. Those rows show a "—:——" placeholder for duration and omit the waveform thumbnail until they get re-processed.